### PR TITLE
Remove is_admin from localStorage (Security Fix)

### DIFF
--- a/src/components/MatchupPredictionCard.js
+++ b/src/components/MatchupPredictionCard.js
@@ -23,7 +23,7 @@ import { TbCrystalBall } from 'react-icons/tb';
 /**
  * Card component displaying a playoff matchup with prediction functionality
  */
-const MatchupPredictionCard = ({ 
+const MatchupPredictionCard = ({
   homeTeam,
   awayTeam,
   matchupId,
@@ -34,7 +34,7 @@ const MatchupPredictionCard = ({
   predictedAwayScore = null,
   round = 1,
   onSubmitPrediction,
-  isAdmin = localStorage.getItem('is_admin') === 'true',
+  isAdmin = false,
   onUpdateScore,
   onViewDetails,
   onActivateMatchup

--- a/src/pages/PredictionsPage.js
+++ b/src/pages/PredictionsPage.js
@@ -59,7 +59,7 @@ const PredictionsPage = () => {
   const [selectedMatchup, setSelectedMatchup] = useState(null);
   const [leaguePredictions, setLeaguePredictions] = useState([]);
   
-  const { user } = useAuth();
+  const { user, isAdmin } = useAuth();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -289,7 +289,7 @@ const PredictionsPage = () => {
         predictedAwayScore={matchup.predictedAwayScore}
         round={matchup.round}
         onSubmitPrediction={handleSubmitPrediction}
-        isAdmin={user?.is_admin}
+        isAdmin={isAdmin}
         onUpdateScore={handleUpdateScore}
         onViewDetails={handleViewDetails}
         onActivateMatchup={handleMatchupActivated}
@@ -340,7 +340,7 @@ const PredictionsPage = () => {
               predictedAwayScore={matchup.predictedAwayScore}
               round={matchup.round}
               onSubmitPrediction={handleSubmitPrediction}
-              isAdmin={user?.is_admin}
+              isAdmin={isAdmin}
               onUpdateScore={handleUpdateScore}
               onViewDetails={handleViewDetails}
               onActivateMatchup={handleMatchupActivated}

--- a/src/services/UserServices.js
+++ b/src/services/UserServices.js
@@ -121,11 +121,7 @@ const UserServices = {
     if (token) {
       localStorage.setItem('auth_token', token);
     }
-    
-    if (userData?.is_admin) {
-      localStorage.setItem('is_admin', userData.is_admin);
-    }
-    
+
     if (userData?.player?.player_id) {
       localStorage.setItem('player_id', userData.player.player_id);
     }
@@ -133,7 +129,7 @@ const UserServices = {
     if (userData?.player?.player_name) {
       localStorage.setItem('player_name', userData.player.player_name);
     }
-    
+
     if (userData?.league?.league_id) {
       localStorage.setItem('league_id', userData.league.league_id);
     }


### PR DESCRIPTION
## Summary

Fixes security vulnerability where `is_admin` was stored in client-side localStorage, allowing users to manipulate it via DevTools and gain access to admin UI elements.

**Changes:**
- Moved `is_admin` from localStorage to AuthContext (React state)
- Admin status is now fetched from backend `/user/check` on every session initialization
- Added retry logic with exponential backoff for resilience
- Components now read `isAdmin` from `useAuth()` hook instead of localStorage

**Security Improvement:**
- Before: Users could run `localStorage.setItem('is_admin', 'true')` to see admin UI
- After: Admin UI visibility controlled by server-verified state that resets on page load
- Backend still protects actual admin actions via `@requires_admin` decorator (defense in depth)

**Architecture Note:**
Admin status is now session-based (memory-only), re-fetched from server on page refresh. This pattern prepares the codebase for future multi-league/multi-player support where user data will be fetched per-route rather than stored globally in localStorage.

## Test Plan

- [x] Normal user login - admin UI not visible
- [x] Admin user login - admin UI visible (Activate/Update Score buttons)
- [x] Page refresh as admin - admin UI persists
- [x] localStorage manipulation has no effect on admin UI visibility
- [x] Backend failure handling - retry logic works, graceful degradation with user notification