### PR TITLE
Add deadline countdown timer and locked state visual polish

### DIFF
--- a/src/components/BracketMatchup.jsx
+++ b/src/components/BracketMatchup.jsx
@@ -170,7 +170,7 @@ const BracketMatchup = ({ matchup: m, isLocked, isFinals, onMatchupClick }) => {
   const cardSx = {
     borderRadius: '10px',
     overflow: 'hidden',
-    opacity: m.isTbd ? 0.38 : 1,
+    opacity: m.isTbd ? 0.38 : isLocked ? 0.6 : 1,
     cursor: isClickable ? 'pointer' : 'default',
     border: isFinals
       ? '1px solid rgba(245,158,11,0.22)'

--- a/src/components/BracketView.jsx
+++ b/src/components/BracketView.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Tabs, Tab, Typography, useTheme, useMediaQuery } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import ConferenceBracket from './ConferenceBracket';
@@ -7,20 +7,54 @@ import BracketMatchup from './BracketMatchup';
 const FINALS_PTS = 30;
 
 /**
- * Progress bar + deadline strip shown above the bracket on all screen sizes.
+ * Formats a millisecond duration into a human-readable countdown string.
+ * Examples: "3d 14h 22m", "5h 12m", "42m", "< 1m"
+ */
+function formatCountdown(ms) {
+  if (ms <= 0) return null;
+  const totalMinutes = Math.floor(ms / 60_000);
+  if (totalMinutes < 1) return '< 1m';
+  const days  = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const mins  = totalMinutes % 60;
+  if (days > 0) return `${days}d ${hours}h ${mins}m`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+/**
+ * Progress bar + deadline countdown strip shown above the bracket on all screen sizes.
+ * Countdown updates every 60 seconds. Text turns red when < 24 hours remain.
  */
 function BracketHeader({ predictedMatchups, totalMatchups, isLocked, deadline }) {
   const theme = useTheme();
+  const [now, setNow] = useState(Date.now());
 
-  const deadlineStr = deadline
-    ? new Date(deadline).toLocaleDateString('en-US', {
-        month: 'short', day: 'numeric', year: 'numeric',
-      })
-    : null;
+  // Tick every 60 s while the bracket is still open
+  useEffect(() => {
+    if (isLocked || !deadline) return;
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, [isLocked, deadline]);
+
+  const remaining   = deadline ? new Date(deadline).getTime() - now : 0;
+  const isUrgent    = remaining > 0 && remaining < 24 * 60 * 60 * 1000; // < 24 h
+  const countdownStr = formatCountdown(remaining);
 
   const pct = totalMatchups > 0
     ? Math.round((predictedMatchups / totalMatchups) * 100)
     : 0;
+
+  // Determine deadline label text and color
+  let deadlineLabel = null;
+  let deadlineColor = 'text.secondary';
+  if (isLocked) {
+    deadlineLabel = '🔒 Bracket locked — deadline passed';
+    deadlineColor = 'error.main';
+  } else if (countdownStr) {
+    deadlineLabel = `🔓 Locks in ${countdownStr}`;
+    deadlineColor = isUrgent ? 'error.main' : 'text.secondary';
+  }
 
   return (
     <Box sx={{
@@ -50,12 +84,12 @@ function BracketHeader({ predictedMatchups, totalMatchups, isLocked, deadline })
         </Box>
       </Box>
 
-      {deadlineStr && (
+      {deadlineLabel && (
         <Typography variant="body2" sx={{
-          fontSize: '0.8rem', whiteSpace: 'nowrap',
-          color: isLocked ? 'error.main' : 'text.secondary',
+          fontSize: '0.8rem', whiteSpace: 'nowrap', fontWeight: isUrgent || isLocked ? 600 : 400,
+          color: deadlineColor,
         }}>
-          {isLocked ? '🔒 Bracket locked' : `🔓 Locks ${deadlineStr}`}
+          {deadlineLabel}
         </Typography>
       )}
     </Box>


### PR DESCRIPTION
## Summary
- Replace static deadline date display with a **live countdown timer** that updates every 60 seconds (e.g., "Locks in 3d 14h 22m")
- Countdown turns **red + bold** when < 24 hours remain
- Lock banner now reads "🔒 Bracket locked — deadline passed" (was just "Bracket locked")
- Matchup cards are **dimmed (opacity 0.6)** when bracket is locked

Closes #16

## Test plan
- [x] Set `PLAYIN_START_DATE` in SeasonConfig.js to ~5 minutes from now, verify countdown shows and ticks
- [x] Set deadline to < 24h away, verify countdown text turns red
- [x] Wait for deadline to pass, verify: lock banner changes, submit button disappears, cards dimmed + non-clickable
- [x] Reset `PLAYIN_START_DATE` to real date after testing