### PR TITLE
Add bracket score column to standings (#18)

### DIFF
--- a/src/components/StandingsTable.jsx
+++ b/src/components/StandingsTable.jsx
@@ -41,12 +41,13 @@ const StandingsTable = ({ players, currentPlayerId, onPlayerSelect }) => {
         </>
       );
     } else if (isTablet) {
-      // On tablet, add championship prediction
+      // On tablet, add championship prediction and bracket score
       return (
         <>
           <TableCell>Rank</TableCell>
           <TableCell>Player</TableCell>
           <TableCell>Championship</TableCell>
+          <TableCell align="right">Bracket</TableCell>
           <TableCell align="right">Score</TableCell>
         </>
       );
@@ -58,6 +59,7 @@ const StandingsTable = ({ players, currentPlayerId, onPlayerSelect }) => {
           <TableCell>Player</TableCell>
           <TableCell>Championship</TableCell>
           <TableCell>MVP</TableCell>
+          <TableCell align="right">Bracket</TableCell>
           <TableCell align="right">Score</TableCell>
         </>
       );
@@ -147,6 +149,7 @@ const StandingsTable = ({ players, currentPlayerId, onPlayerSelect }) => {
             </Box>
           </TableCell>
           <TableCell>{player.championshipPrediction}</TableCell>
+          <TableCell align="right">{player.bracketScore}</TableCell>
           <TableCell align="right">
             <Typography fontWeight="bold">{player.score}</Typography>
           </TableCell>
@@ -167,11 +170,11 @@ const StandingsTable = ({ players, currentPlayerId, onPlayerSelect }) => {
           </TableCell>
           <TableCell>
             <Box display="flex" alignItems="center">
-            <Avatar 
-              sx={{ 
-                width: 32, 
-                height: 32, 
-                mr: 1, 
+            <Avatar
+              sx={{
+                width: 32,
+                height: 32,
+                mr: 1,
                 bgcolor: isCurrentPlayer ? theme.palette.primary.main : theme.palette.grey[300],
                 fontSize: '0.875rem'
               }}
@@ -188,6 +191,7 @@ const StandingsTable = ({ players, currentPlayerId, onPlayerSelect }) => {
           </TableCell>
           <TableCell>{player.championshipPrediction}</TableCell>
           <TableCell>{player.mvpPrediction}</TableCell>
+          <TableCell align="right">{player.bracketScore}</TableCell>
           <TableCell align="right">
             <Typography fontWeight="bold">{player.score}</Typography>
           </TableCell>
@@ -243,6 +247,7 @@ StandingsTable.propTypes = {
       championshipPrediction: PropTypes.string,
       mvpPrediction: PropTypes.string,
       player_avatar: PropTypes.string,
+      bracketScore: PropTypes.number,
       score: PropTypes.number.isRequired
     })
   ).isRequired,

--- a/src/services/LeagueServices.js
+++ b/src/services/LeagueServices.js
@@ -51,6 +51,7 @@ const transformPlayerData = (player) => ({
   score: player.total_points,
   championship_team_points: player.championship_team_points,
   mvp_points: player.mvp_points,
+  bracketScore: player.bracket_score || 0,
   bullsEye: player.bullsEye,
   hits: player.hits,
   misses: player.misses,


### PR DESCRIPTION
## Summary
- Add `bracketScore` field mapping in `LeagueServices.transformPlayerData()`
- Add "Bracket" column to StandingsTable on desktop and tablet views
- Mobile view unchanged (already compact)

## Test plan
- [x] Navigate to league standings, verify Bracket column appears on desktop/tablet
- [ ] Verify bracket score values display correctly (0 by default until playoffs begin)