### PR TITLE
Add bracket diff auto-highlight for league member comparison

### DIFF
--- a/src/components/BracketMatchup.jsx
+++ b/src/components/BracketMatchup.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Paper, Typography, useTheme } from '@mui/material';
+import { Box, Paper, Tooltip, Typography, useTheme } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { getLogoPath } from '../shared/teamUtils';
 
@@ -159,13 +159,22 @@ function TeamRow({ team, seed, isPredWinner, isActualWinner, hasPick, isPlayed }
  *   isFinals       — apply gold accent styling for the NBA Finals card
  *   onMatchupClick — (matchup) => void; when provided and matchup.can_edit, card is clickable
  */
-const BracketMatchup = ({ matchup: m, isLocked, isFinals, onMatchupClick }) => {
+const BracketMatchup = ({ matchup: m, isLocked, isFinals, onMatchupClick, diffState }) => {
   const theme = useTheme();
 
   if (!m) return null;
 
   // Clickable when: a handler is provided AND can_edit is true AND bracket is not locked
   const isClickable = Boolean(onMatchupClick && m.can_edit && !isLocked);
+
+  // Diff colour lookup — card-level border + background tint when comparing brackets
+  const DIFF_COLORS = {
+    exact:     { border: theme.palette.success.main,  bg: alpha(theme.palette.success.main, 0.10) },
+    partial:   { border: theme.palette.warning.main,  bg: alpha(theme.palette.warning.main, 0.10) },
+    different: { border: theme.palette.error.main,    bg: alpha(theme.palette.error.main, 0.10) },
+    diverged:  { border: theme.palette.grey[500],     bg: alpha(theme.palette.grey[500], 0.06) },
+  };
+  const diffColor = diffState ? DIFF_COLORS[diffState.state] : null;
 
   const cardSx = {
     borderRadius: '10px',
@@ -183,6 +192,12 @@ const BracketMatchup = ({ matchup: m, isLocked, isFinals, onMatchupClick }) => {
       transform: 'translateY(-1px)',
       boxShadow: theme.shadows[4],
     } : {},
+    // Diff overlay — coloured left border + subtle background tint
+    ...(diffColor && {
+      borderLeft: `3px solid ${diffColor.border}`,
+      background: diffColor.bg,
+      opacity: m.isTbd ? 0.38 : 1, // Full opacity in diff mode for better readability
+    }),
   };
 
   // predWinnerIsTeam1: true when pick points to team_1
@@ -200,7 +215,19 @@ const BracketMatchup = ({ matchup: m, isLocked, isFinals, onMatchupClick }) => {
     : null;
   const actScore  = m.isPlayed ? m.actual_series_score : null;
 
+  const tooltipText = diffState?.tooltip ?? '';
+
   return (
+    <Tooltip
+      title={tooltipText}
+      placement="top"
+      arrow
+      disableHoverListener={!tooltipText}
+      enterDelay={200}
+      slotProps={{
+        tooltip: { sx: { fontSize: '0.75rem', maxWidth: 260 } },
+      }}
+    >
     <Paper
       elevation={0}
       sx={cardSx}
@@ -252,6 +279,7 @@ const BracketMatchup = ({ matchup: m, isLocked, isFinals, onMatchupClick }) => {
         </Box>
       )}
     </Paper>
+    </Tooltip>
   );
 };
 

--- a/src/components/BracketRound.jsx
+++ b/src/components/BracketRound.jsx
@@ -22,7 +22,7 @@ const COL_WIDTH = {
  *   isLocked    — passed down to BracketMatchup
  *   mobile      — renders a stacked grid layout instead of fixed-width column
  */
-const BracketRound = ({ label, pts, matchups, isPlayinCol, isLocked, mobile, onMatchupClick }) => {
+const BracketRound = ({ label, pts, matchups, isPlayinCol, isLocked, mobile, onMatchupClick, diffMap, roundKey }) => {
   const theme = useTheme();
 
   const pillSx = isPlayinCol
@@ -82,6 +82,7 @@ const BracketRound = ({ label, pts, matchups, isPlayinCol, isLocked, mobile, onM
               matchup={m}
               isLocked={isLocked}
               onMatchupClick={onMatchupClick}
+              diffState={diffMap?.[`${m.conference}-${roundKey}-${m.matchup_position}`] ?? null}
             />
           ))}
         </Box>
@@ -110,6 +111,7 @@ const BracketRound = ({ label, pts, matchups, isPlayinCol, isLocked, mobile, onM
             matchup={m}
             isLocked={isLocked}
             onMatchupClick={onMatchupClick}
+            diffState={diffMap?.[`${m.conference}-${roundKey}-${m.matchup_position}`] ?? null}
           />
         ))}
       </Box>

--- a/src/components/BracketView.jsx
+++ b/src/components/BracketView.jsx
@@ -99,7 +99,7 @@ function BracketHeader({ predictedMatchups, totalMatchups, isLocked, deadline })
 /**
  * The centered Finals column — trophy, title, points badge, and the Finals matchup card.
  */
-function FinalsSection({ finalMatchup, isLocked, onMatchupClick }) {
+function FinalsSection({ finalMatchup, isLocked, onMatchupClick, diffMap }) {
   return (
     <Box sx={{
       display: 'flex', flexDirection: 'column',
@@ -130,7 +130,7 @@ function FinalsSection({ finalMatchup, isLocked, onMatchupClick }) {
         </Typography>
       </Box>
       <Box sx={{ width: '100%' }}>
-        <BracketMatchup matchup={finalMatchup} isLocked={isLocked} isFinals onMatchupClick={onMatchupClick} />
+        <BracketMatchup matchup={finalMatchup} isLocked={isLocked} isFinals onMatchupClick={onMatchupClick} diffState={diffMap?.[`final-final-${finalMatchup?.matchup_position ?? 1}`] ?? null} />
       </Box>
     </Box>
   );
@@ -141,7 +141,7 @@ function FinalsSection({ finalMatchup, isLocked, onMatchupClick }) {
  * Desktop: West (5 cols) | Finals (center) | East (5 cols) in a horizontally scrollable row.
  * Mobile:  Tabs (West / Finals / East) each rendering their rounds vertically.
  */
-const BracketView = ({ bracket, isLocked, predictedMatchups, totalMatchups, deadline, onMatchupClick }) => {
+const BracketView = ({ bracket, isLocked, predictedMatchups, totalMatchups, deadline, onMatchupClick, diffMap }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [mobileTab, setMobileTab] = useState(0);
@@ -171,7 +171,7 @@ const BracketView = ({ bracket, isLocked, predictedMatchups, totalMatchups, dead
         </Tabs>
 
         {mobileTab === 0 && (
-          <ConferenceBracket conf="west" rounds={bracket.west} isLocked={isLocked} onMatchupClick={onMatchupClick} mobile />
+          <ConferenceBracket conf="west" rounds={bracket.west} isLocked={isLocked} onMatchupClick={onMatchupClick} diffMap={diffMap} mobile />
         )}
         {mobileTab === 1 && (
           <Box sx={{ px: 2, maxWidth: 380, mx: 'auto' }}>
@@ -196,11 +196,11 @@ const BracketView = ({ bracket, isLocked, predictedMatchups, totalMatchups, dead
                 {FINALS_PTS} pts
               </Typography>
             </Box>
-            <BracketMatchup matchup={bracket.final} isLocked={isLocked} isFinals onMatchupClick={onMatchupClick} />
+            <BracketMatchup matchup={bracket.final} isLocked={isLocked} isFinals onMatchupClick={onMatchupClick} diffState={diffMap?.[`final-final-${bracket.final?.matchup_position ?? 1}`] ?? null} />
           </Box>
         )}
         {mobileTab === 2 && (
-          <ConferenceBracket conf="east" rounds={bracket.east} isLocked={isLocked} onMatchupClick={onMatchupClick} mobile />
+          <ConferenceBracket conf="east" rounds={bracket.east} isLocked={isLocked} onMatchupClick={onMatchupClick} diffMap={diffMap} mobile />
         )}
       </Box>
     );
@@ -218,9 +218,9 @@ const BracketView = ({ bracket, isLocked, predictedMatchups, totalMatchups, dead
           alignItems: 'flex-start',
           px: 1.5,
         }}>
-          <ConferenceBracket conf="west" rounds={bracket.west} isLocked={isLocked} onMatchupClick={onMatchupClick} />
-          <FinalsSection finalMatchup={bracket.final} isLocked={isLocked} onMatchupClick={onMatchupClick} />
-          <ConferenceBracket conf="east" rounds={bracket.east} isLocked={isLocked} onMatchupClick={onMatchupClick} />
+          <ConferenceBracket conf="west" rounds={bracket.west} isLocked={isLocked} onMatchupClick={onMatchupClick} diffMap={diffMap} />
+          <FinalsSection finalMatchup={bracket.final} isLocked={isLocked} onMatchupClick={onMatchupClick} diffMap={diffMap} />
+          <ConferenceBracket conf="east" rounds={bracket.east} isLocked={isLocked} onMatchupClick={onMatchupClick} diffMap={diffMap} />
         </Box>
       </Box>
     </Box>

--- a/src/components/ConferenceBracket.jsx
+++ b/src/components/ConferenceBracket.jsx
@@ -23,7 +23,7 @@ const ROUND_DEFS = [
  *   isLocked — passed down to cards
  *   mobile   — mobile layout: chronological order, full-width stacked
  */
-const ConferenceBracket = ({ conf, rounds, isLocked, mobile, onMatchupClick }) => {
+const ConferenceBracket = ({ conf, rounds, isLocked, mobile, onMatchupClick, diffMap }) => {
   const theme = useTheme();
   const isEast   = conf === 'east';
   const title    = isEast ? 'Eastern Conference' : 'Western Conference';
@@ -43,6 +43,8 @@ const ConferenceBracket = ({ conf, rounds, isLocked, mobile, onMatchupClick }) =
             isPlayinCol={isPlayinCol}
             isLocked={isLocked}
             onMatchupClick={onMatchupClick}
+            diffMap={diffMap}
+            roundKey={key}
             mobile
           />
         ))}
@@ -75,6 +77,8 @@ const ConferenceBracket = ({ conf, rounds, isLocked, mobile, onMatchupClick }) =
             isPlayinCol={isPlayinCol}
             isLocked={isLocked}
             onMatchupClick={onMatchupClick}
+            diffMap={diffMap}
+            roundKey={key}
           />
         ))}
       </Box>

--- a/src/components/LeagueBracketsDialog.jsx
+++ b/src/components/LeagueBracketsDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   Dialog,
@@ -28,12 +28,13 @@ import { alpha } from '@mui/material/styles';
 import { PLAYER_AVATARS } from '../shared/GeneralConsts';
 import BracketServices from '../services/BracketServices';
 import BracketView from './BracketView';
+import { computeBracketDiff } from '../utils/bracketUtils';
 
 /**
  * Dialog for viewing league members' brackets after the deadline.
  * Shows a player list with bracket status; clicking a player loads their full bracket.
  */
-const LeagueBracketsDialog = ({ open, onClose, leagueId, currentPlayerId }) => {
+const LeagueBracketsDialog = ({ open, onClose, leagueId, currentPlayerId, myBracket }) => {
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -47,6 +48,14 @@ const LeagueBracketsDialog = ({ open, onClose, leagueId, currentPlayerId }) => {
   const [bracketData, setBracketData] = useState(null);
   const [loadingBracket, setLoadingBracket] = useState(false);
   const [bracketError, setBracketError] = useState(null);
+
+  // Compute bracket diff when viewing another player's bracket
+  const diffResult = useMemo(() => {
+    if (!myBracket || !bracketData) return null;
+    if (selectedPlayer?.playerId === currentPlayerId) return null;
+    
+    return computeBracketDiff(myBracket, bracketData);
+  }, [myBracket, bracketData, selectedPlayer, currentPlayerId]);
 
   // Fetch league bracket status when dialog opens
   useEffect(() => {
@@ -253,6 +262,7 @@ const LeagueBracketsDialog = ({ open, onClose, leagueId, currentPlayerId }) => {
         totalMatchups={bracketData.totalMatchups}
         deadline={bracketData.deadline}
         onMatchupClick={undefined}
+        diffMap={diffResult?.slots ?? null}
       />
     );
   };
@@ -278,6 +288,15 @@ const LeagueBracketsDialog = ({ open, onClose, leagueId, currentPlayerId }) => {
       <Typography variant="h6" noWrap>
         {selectedPlayer.playerName}'s Bracket
       </Typography>
+      {diffResult && (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ ml: 'auto', whiteSpace: 'nowrap', fontSize: '0.8rem' }}
+        >
+          {diffResult.summary.exact} exact / {diffResult.summary.sameWinner} same winner of {diffResult.summary.total}
+        </Typography>
+      )}
     </Box>
   ) : (
     <Typography variant="h6">League Brackets</Typography>
@@ -316,6 +335,33 @@ const LeagueBracketsDialog = ({ open, onClose, leagueId, currentPlayerId }) => {
         </IconButton>
       </DialogTitle>
       <Divider />
+      {/* Colour legend — only shown when viewing another player's bracket */}
+      {diffResult && (
+        <Box sx={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          flexWrap: 'wrap', gap: { xs: 1, sm: 2 },
+          px: 2, py: 1,
+          background: alpha(theme.palette.divider, 0.08),
+          borderBottom: `1px solid ${theme.palette.divider}`,
+        }}>
+          {[
+            { color: theme.palette.success.main, label: 'Exact match' },
+            { color: theme.palette.warning.main, label: 'Same winner' },
+            { color: theme.palette.error.main,   label: 'Different winner' },
+            { color: theme.palette.grey[500],     label: 'Not comparable' },
+          ].map(({ color, label }) => (
+            <Box key={label} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Box sx={{
+                width: 10, height: 10, borderRadius: '2px',
+                background: color, flexShrink: 0,
+              }} />
+              <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
+                {label}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
       <DialogContent sx={{ p: selectedPlayer ? 2 : 0 }}>
         {selectedPlayer ? renderBracketView() : renderPlayerList()}
       </DialogContent>
@@ -328,6 +374,7 @@ LeagueBracketsDialog.propTypes = {
   onClose: PropTypes.func.isRequired,
   leagueId: PropTypes.string,
   currentPlayerId: PropTypes.string,
+  myBracket: PropTypes.object,
 };
 
 export default LeagueBracketsDialog;

--- a/src/pages/BracketPage.jsx
+++ b/src/pages/BracketPage.jsx
@@ -252,6 +252,7 @@ const BracketPage = () => {
         onClose={() => setLeagueBracketsOpen(false)}
         leagueId={activePlayer.league_id}
         currentPlayerId={activePlayer.player_id}
+        myBracket={bracketState}
       />
     </>
   );

--- a/src/utils/bracketUtils.js
+++ b/src/utils/bracketUtils.js
@@ -271,3 +271,119 @@ export function flattenBracketPicks(bracketState) {
 
   return picks;
 }
+
+// ---------------------------------------------------------------------------
+// Bracket diff — compare two brackets slot-by-slot (Issue #32)
+// ---------------------------------------------------------------------------
+
+/** Diff state constants */
+const DIFF_EXACT     = 'exact';     // Same winner AND same series score (green)
+const DIFF_PARTIAL   = 'partial';   // Same winner, different series score (amber)
+const DIFF_DIFFERENT = 'different'; // Different winner, at least one team shared (red)
+const DIFF_DIVERGED  = 'diverged';  // Both teams differ entirely OR missing pick (grey)
+
+/**
+ * Computes the diff state + tooltip for a single matchup slot.
+ * Returns { state, tooltip } where tooltip is a human-readable explanation.
+ */
+function diffSlot(myM, theirM) {
+  // Missing pick on either side → diverged
+  if (!myM?.hasPick || !theirM?.hasPick) {
+    return { state: DIFF_DIVERGED, tooltip: 'Missing pick — not comparable' };
+  }
+
+  // Check team overlap — do the two brackets share at least one team in this slot?
+  const myTeams   = new Set([myM.team_1?.team_id, myM.team_2?.team_id].filter(Boolean));
+  const theirTeams = new Set([theirM.team_1?.team_id, theirM.team_2?.team_id].filter(Boolean));
+  let sharedCount = 0;
+  for (const id of myTeams) {
+    if (theirTeams.has(id)) sharedCount++;
+  }
+
+  // No teams in common → tree diverged entirely
+  if (sharedCount === 0) {
+    return { state: DIFF_DIVERGED, tooltip: 'Different bracket paths — not comparable' };
+  }
+
+  // Resolve winner names for tooltip
+  const myWinner    = myM.predicted_winner_team_id === myM.team_1?.team_id ? myM.team_1 : myM.team_2;
+  const theirWinner = theirM.predicted_winner_team_id === theirM.team_1?.team_id ? theirM.team_1 : theirM.team_2;
+
+  // Same winner?
+  if (myM.predicted_winner_team_id !== theirM.predicted_winner_team_id) {
+    return {
+      state: DIFF_DIFFERENT,
+      tooltip: `You picked ${myWinner?.name ?? '?'}, they picked ${theirWinner?.name ?? '?'}`,
+    };
+  }
+
+  // Same winner — for play-in rounds there's no series score, so it's always exact
+  const isPlayin = myM.isPlayin;
+  if (isPlayin) {
+    return { state: DIFF_EXACT, tooltip: `Both picked ${myWinner?.name ?? '?'}` };
+  }
+
+  // Compare series score
+  if (myM.predicted_series_score === theirM.predicted_series_score) {
+    return {
+      state: DIFF_EXACT,
+      tooltip: `Both picked ${myWinner?.name ?? '?'} in ${myM.predicted_series_score}`,
+    };
+  }
+  return {
+    state: DIFF_PARTIAL,
+    tooltip: `Both picked ${myWinner?.name ?? '?'} — you said ${myM.predicted_series_score}, they said ${theirM.predicted_series_score}`,
+  };
+}
+
+/**
+ * Compares two bracket states slot-by-slot and returns a diff map + summary.
+ *
+ * Both brackets must be in the transformed shape produced by
+ * BracketServices.transformBracketData (component round keys, enriched matchups).
+ *
+ * @param {Object} myBracket    - Viewer's own bracket state
+ * @param {Object} theirBracket - Other player's bracket state
+ * @returns {{ slots: Object, summary: { exact: number, sameWinner: number, total: number } }}
+ */
+export function computeBracketDiff(myBracket, theirBracket) {
+  if (!myBracket || !theirBracket) return null;
+
+  const slots = {};
+  let exact = 0;
+  let sameWinner = 0;
+  const ROUND_KEYS = ['playin', 'survivor', 'r1', 'semis', 'cf'];
+
+  for (const conf of ['east', 'west']) {
+    for (const roundKey of ROUND_KEYS) {
+      const myRound    = myBracket[conf]?.[roundKey] || [];
+      const theirRound = theirBracket[conf]?.[roundKey] || [];
+      const len = Math.max(myRound.length, theirRound.length);
+
+      for (let i = 0; i < len; i++) {
+        const myM    = myRound[i] || null;
+        const theirM = theirRound[i] || null;
+        const pos    = myM?.matchup_position ?? theirM?.matchup_position ?? (i + 1);
+        const slotKey = `${conf}-${roundKey}-${pos}`;
+
+        const diff = diffSlot(myM, theirM);
+        slots[slotKey] = diff;
+
+        if (diff.state === DIFF_EXACT)   { exact++; sameWinner++; }
+        if (diff.state === DIFF_PARTIAL) { sameWinner++; }
+      }
+    }
+  }
+
+  // Finals
+  const finalsDiff = diffSlot(myBracket.final, theirBracket.final);
+  const finalsPos = myBracket.final?.matchup_position ?? 1;
+  slots[`final-final-${finalsPos}`] = finalsDiff;
+  if (finalsDiff.state === DIFF_EXACT)   { exact++; sameWinner++; }
+  if (finalsDiff.state === DIFF_PARTIAL) { sameWinner++; }
+
+  return {
+    slots,
+    summary: { exact, sameWinner, total: 21 },
+  };
+}


### PR DESCRIPTION
## Summary
- Add colour-coded diff overlay when viewing another league member's bracket in `LeagueBracketsDialog`
- 4-state positional comparison across all 21 bracket slots: **exact match** (green), **same winner** (amber), **different winner** (red), **not comparable** (grey)
- Color legend bar in dialog header + contextual tooltips on hover + summary count in title bar
- Self-view rule: no diff styling when viewing own bracket

## Implementation
- `computeBracketDiff()` utility in `bracketUtils.js` — positional slot comparison using component round keys
- `diffMap` prop threaded through 6 component levels: `BracketPage` → `LeagueBracketsDialog` → `BracketView` → `ConferenceBracket` → `BracketRound` → `BracketMatchup`
- Theme-aware card styling via MUI `alpha()` and theme tokens (left border + background tint)

## Known Limitations (backlog)
- Mobile: tooltip hover not supported on touch devices
- Mobile: summary count text may be cut off on narrow screens
- These will be addressed in the broader bracket UI/UX refactor

## Test Plan
- [x] Open League Brackets dialog, select another player → verify 4 diff color states render correctly
- [x] View own bracket → no diff colors or summary shown
- [x] Desktop: legend bar, tooltips, summary count all visible
- [x] Dark mode: colors are theme-aware
- [x] Regression: own bracket page (outside dialog) has no diff styling

Closes #32