### PR TITLE
Fix player avatars in MatchupDetailsDialog

### DIFF
--- a/src/components/MatchupDetailsDialog.js
+++ b/src/components/MatchupDetailsDialog.js
@@ -24,6 +24,7 @@ import MatchupTeamsDisplay from './common/MatchupTeamsDisplay';
 import MatchupScoreDisplay from './common/MatchupScoreDisplay';
 import MatchupPredictionsStats from './MatchupPredictionsStats';
 import { useAuth } from '../contexts/AuthContext';
+import { PLAYER_AVATARS } from '../shared/GeneralConsts';
 
 /**
  * Dialog to display league predictions for a matchup
@@ -241,8 +242,8 @@ const MatchupDetailsDialog = ({
                     flexDirection: { xs: 'column', sm: 'row' },
                     mb: { xs: 1, sm: 0 }
                   }}>
-                    <Avatar 
-                      src={prediction.userAvatar} 
+                    <Avatar
+                      src={PLAYER_AVATARS.find(a => a.id === prediction.userAvatar)?.src}
                       alt={prediction.userName}
                       sx={{ mr: { xs: 0, sm: 2 }, mb: { xs: 1, sm: 0 } }}
                     >

--- a/src/services/MatchupServices.js
+++ b/src/services/MatchupServices.js
@@ -147,6 +147,7 @@ const MatchupServices = {
       // Transform the response to match the expected format in the MatchupDetailsDialog
       const transformedPredictions = response.predictions.map(pred => ({
         userName: pred.player_name,
+        userAvatar: pred.player_avatar,
         homeScore: pred.prediction.home_team_score,
         awayScore: pred.prediction.away_team_score,
         hit: pred.prediction.hit,


### PR DESCRIPTION
## Summary
- `MatchupDetailsDialog` now renders player avatars correctly
- Root cause: `MatchupServices.getMatchupPredictions` was discarding `player_avatar` from the API response — it's now mapped to `userAvatar`
- `MatchupDetailsDialog` now looks up the avatar `src` via `PLAYER_AVATARS.find(a => a.id === prediction.userAvatar)?.src` (same pattern used in StandingsTable, LeagueBracketsDialog, etc.)

## Related
Closes #20
Companion server PR: darchock/NBA-Playoffs-Brackets-App-Server#60

## Test Plan
- [x] Open MatchupDetailsDialog for a matchup — player avatars should now appear next to each prediction entry