### PR TITLE
Fix R1 bracket display order to match NBA bracket tree

### DIFF
--- a/src/components/ConferenceBracket.jsx
+++ b/src/components/ConferenceBracket.jsx
@@ -16,8 +16,8 @@ const ROUND_DEFS = [
 
 // NBA bracket layout: adjacent pairs feed into the same semis matchup.
 // Top half: pos 1 (1v8) + pos 4 (4v5) → semis pos 1
-// Bottom half: pos 2 (2v7) + pos 3 (3v6) → semis pos 2
-const R1_DISPLAY_ORDER = [1, 4, 2, 3];
+// Bottom half: pos 3 (3v6) + pos 2 (2v7) → semis pos 2
+const R1_DISPLAY_ORDER = [1, 4, 3, 2];
 
 function reorderForDisplay(matchups, roundKey) {
   if (roundKey !== 'r1' || matchups.length !== 4) return matchups;


### PR DESCRIPTION
## Summary
- Reorder Round 1 matchups from `[1, 2, 3, 4]` to `[1, 4, 3, 2]` so adjacent pairs feed into the correct semis matchup
- Top half: 1v8 (pos 1) + 4v5 (pos 4) → semis pos 1
- Bottom half: 3v6 (pos 3) + 2v7 (pos 2) → semis pos 2
- Display-only change in `ConferenceBracket.jsx` — data arrays and pick logic remain sorted by `matchup_position`

Closes #39

## Test plan
- [x] Desktop: R1 shows 1v8, 4v5 in top half and 3v6, 2v7 in bottom half
- [x] Desktop: Adjacent R1 pairs visually align with their semis matchup
- [x] Pick a R1 winner → correct semis slot gets populated
- [x] Submit full bracket → all 21 picks submit correctly
- [x] Mobile: Same R1 order applies
- [x] Empty bracket (new player) → TBD slots in correct order