### PR TITLE
feat: add unsaved bracket warning when navigating away (#40)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,12 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { ToastContainer, toast } from 'react-toastify';
+import {
+  createBrowserRouter,
+  createRoutesFromElements,
+  Navigate,
+  Route,
+  RouterProvider,
+} from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import ThemeProvider from './theme/ThemeProvider';
@@ -16,76 +22,97 @@ import CreateLeaguePage from './pages/CreateLeaguePage';
 import CreatePlayerPage from './pages/CreatePlayerPage';
 import BracketPage from './pages/BracketPage';
 
-function AppContent() {
-  const { logout, isAuthenticated } = useAuth();
-  
-  const handleLogout = () => {
-    logout(); // From AuthContext.useAuth()
-  };
-  
+function CreateLeagueRoute() {
+  const { logout } = useAuth();
   return (
-    <Router>
-<Routes>
-  {/* Public landing page now at "/" */}
-  <Route path="/" element={<LandingPage />} />
-
-  {/* Protected routes */}
-  <Route element={<ProtectedRoute />}>
-    <Route path="/create-league" element={
-      <>
-        <StandaloneHeader title="Create League" onLogout={handleLogout} />
-        <div className="container mx-auto mt-8 px-4">
-          <CreateLeaguePage />
-        </div>
-      </>
-    } />
-    
-    <Route path="/create-player" element={
-      <>
-        <StandaloneHeader title="Create Player" onLogout={handleLogout} />
-        <div className="container mx-auto mt-8 px-4">
-          <CreatePlayerPage />
-        </div>
-      </>
-    } />
-
-    <Route path="/dashboard" element={
-      <Layout onLogout={handleLogout}>
-        <Dashboard />
-      </Layout>
-    } />
-
-    <Route path="/predictions" element={
-      <Layout onLogout={handleLogout}>
-        <PredictionsPage />
-      </Layout>
-    } />
-
-    <Route path="/league" element={
-      <Layout onLogout={handleLogout}>
-        <LeaguePage />
-      </Layout>
-    } />
-
-    <Route path="/profile" element={
-      <Layout onLogout={handleLogout}>
-        <ProfilePage />
-      </Layout>
-    } />
-
-    <Route path="/bracket" element={
-      <Layout onLogout={handleLogout}>
-        <BracketPage />
-      </Layout>
-    } />
-  </Route>
-
-  {/* Redirect anything unknown to "/" (landing) */}
-  <Route path="*" element={<Navigate to="/" replace />} />
-</Routes>
-
-    </Router>
+    <>
+      <StandaloneHeader title="Create League" onLogout={logout} />
+      <div className="container mx-auto mt-8 px-4">
+        <CreateLeaguePage />
+      </div>
+    </>
   );
+}
+
+function CreatePlayerRoute() {
+  const { logout } = useAuth();
+  return (
+    <>
+      <StandaloneHeader title="Create Player" onLogout={logout} />
+      <div className="container mx-auto mt-8 px-4">
+        <CreatePlayerPage />
+      </div>
+    </>
+  );
+}
+
+function AppLayoutRoute({ children }) {
+  const { logout } = useAuth();
+  return <Layout onLogout={logout}>{children}</Layout>;
+}
+
+const router = createBrowserRouter(
+  createRoutesFromElements(
+    <>
+      <Route path="/" element={<LandingPage />} />
+
+      <Route element={<ProtectedRoute />}>
+        <Route path="/create-league" element={<CreateLeagueRoute />} />
+        <Route path="/create-player" element={<CreatePlayerRoute />} />
+
+        <Route
+          path="/dashboard"
+          element={(
+            <AppLayoutRoute>
+              <Dashboard />
+            </AppLayoutRoute>
+          )}
+        />
+
+        <Route
+          path="/predictions"
+          element={(
+            <AppLayoutRoute>
+              <PredictionsPage />
+            </AppLayoutRoute>
+          )}
+        />
+
+        <Route
+          path="/league"
+          element={(
+            <AppLayoutRoute>
+              <LeaguePage />
+            </AppLayoutRoute>
+          )}
+        />
+
+        <Route
+          path="/profile"
+          element={(
+            <AppLayoutRoute>
+              <ProfilePage />
+            </AppLayoutRoute>
+          )}
+        />
+
+        <Route
+          path="/bracket"
+          element={(
+            <AppLayoutRoute>
+              <BracketPage />
+            </AppLayoutRoute>
+          )}
+        />
+      </Route>
+
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </>,
+  ),
+);
+
+function AppContent() {
+  return <RouterProvider router={router} />;
 }
 
 function App() {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -7,6 +7,10 @@ import {
 } from 'firebase/auth';
 import { auth } from '../firebase';
 import UserServices from '../services/UserServices';
+import {
+  confirmBracketExitIfNeeded,
+  runWithBracketGuardBypass,
+} from '../utils/navigationGuards';
 
 // Create the authentication context
 const AuthContext = createContext();
@@ -69,6 +73,10 @@ export function AuthProvider({ children }) {
    * the selection in localStorage so it survives page reloads.
    */
   const switchActivePlayer = useCallback((playerId) => {
+    if (!confirmBracketExitIfNeeded()) {
+      return false;
+    }
+
     const player = userPlayers.find(p => p.player_id === playerId);
     if (player) {
       setActivePlayer(player);
@@ -77,7 +85,10 @@ export function AuthProvider({ children }) {
       if (window.notify) {
         window.notify.success(`Switched to ${player.league_name}`);
       }
+
+      return true;
     }
+    return false;
   }, [userPlayers]);
 
   // Sign in with Google with retry logic
@@ -157,6 +168,10 @@ export function AuthProvider({ children }) {
 
   // Sign out
   const logout = async () => {
+    if (!confirmBracketExitIfNeeded()) {
+      return false;
+    }
+
     try {
       setError(null);
       await signOut(auth);
@@ -174,7 +189,10 @@ export function AuthProvider({ children }) {
       localStorage.removeItem('active_player_id');
 
       // Redirect user
-      window.location.href = '/';
+      await runWithBracketGuardBypass(async () => {
+        window.location.href = '/';
+      });
+      return true;
     } catch (err) {
       setError(err.message);
       console.error("Error signing out", err);

--- a/src/pages/BracketPage.jsx
+++ b/src/pages/BracketPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   Box, Button, CircularProgress, Alert, Typography,
 } from '@mui/material';
+import { useBlocker } from 'react-router-dom';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import GroupsIcon from '@mui/icons-material/Groups';
@@ -22,6 +23,8 @@ const API_TO_COMPONENT_ROUND = {
   conference_final:  'cf',
   final:             'final',
 };
+
+const UNSAVED_CHANGES_MESSAGE = 'You have unsaved bracket picks. Leave this page without submitting?';
 
 const BracketPage = () => {
   // serverBracket: last confirmed server state — used to detect unsaved changes
@@ -87,9 +90,11 @@ const BracketPage = () => {
     return !picksMatch(bracketState, serverBracket);
   }, [bracketState, serverBracket, predictedCount]);
 
+  const blocker = useBlocker(hasUnsavedChanges);
+
   // -------------------------------------------------------------------------
-  // Navigation guard — tab close / browser back button
-  // (In-app nav guard requires createBrowserRouter; skipped here — beforeunload covers the critical case)
+  // Navigation guard for tab close / browser refresh.
+  // In-app navigation is handled below via useBlocker.
   useEffect(() => {
     const handler = (e) => {
       if (hasUnsavedChanges) {
@@ -100,6 +105,15 @@ const BracketPage = () => {
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
   }, [hasUnsavedChanges]);
+
+  useEffect(() => {
+    if (blocker.state !== 'blocked') return;
+    if (window.confirm(UNSAVED_CHANGES_MESSAGE)) {
+      blocker.proceed();
+    } else {
+      blocker.reset();
+    }
+  }, [blocker]);
 
   // -------------------------------------------------------------------------
   // Handlers
@@ -258,3 +272,4 @@ const BracketPage = () => {
 };
 
 export default BracketPage;
+

--- a/src/pages/BracketPage.jsx
+++ b/src/pages/BracketPage.jsx
@@ -12,7 +12,12 @@ import PredictionDialog from '../components/PredictionDialog';
 import LeagueBracketsDialog from '../components/LeagueBracketsDialog';
 import BracketServices from '../services/BracketServices';
 import { applyPick, countPicks, picksMatch, flattenBracketPicks } from '../utils/bracketUtils';
-
+import {
+  clearBracketUnsavedChangesFlag,
+  confirmBracketExitIfNeeded,
+  setBracketUnsavedChangesFlag,
+  shouldWarnOnBracketExit,
+} from '../utils/navigationGuards';
 // PredictionDialog passes matchup.round (API key: 'playin_first', 'first', etc.)
 // but applyPick / bracketUtils work with component round keys ('playin', 'r1', etc.)
 const API_TO_COMPONENT_ROUND = {
@@ -23,8 +28,6 @@ const API_TO_COMPONENT_ROUND = {
   conference_final:  'cf',
   final:             'final',
 };
-
-const UNSAVED_CHANGES_MESSAGE = 'You have unsaved bracket picks. Leave this page without submitting?';
 
 const BracketPage = () => {
   // serverBracket: last confirmed server state — used to detect unsaved changes
@@ -92,23 +95,28 @@ const BracketPage = () => {
 
   const blocker = useBlocker(hasUnsavedChanges);
 
+  useEffect(() => {
+    setBracketUnsavedChangesFlag(hasUnsavedChanges);
+    return () => clearBracketUnsavedChangesFlag();
+  }, [hasUnsavedChanges]);
+
   // -------------------------------------------------------------------------
   // Navigation guard for tab close / browser refresh.
   // In-app navigation is handled below via useBlocker.
   useEffect(() => {
     const handler = (e) => {
-      if (hasUnsavedChanges) {
+      if (shouldWarnOnBracketExit()) {
         e.preventDefault();
         e.returnValue = '';
       }
     };
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
-  }, [hasUnsavedChanges]);
+  }, []);
 
   useEffect(() => {
     if (blocker.state !== 'blocked') return;
-    if (window.confirm(UNSAVED_CHANGES_MESSAGE)) {
+    if (confirmBracketExitIfNeeded()) {
       blocker.proceed();
     } else {
       blocker.reset();

--- a/src/utils/navigationGuards.js
+++ b/src/utils/navigationGuards.js
@@ -1,0 +1,40 @@
+export const BRACKET_UNSAVED_EXIT_MESSAGE = 'You have unsaved bracket picks. Leave this page without submitting?';
+
+const BRACKET_UNSAVED_FLAG = '__hasUnsavedBracketChanges';
+const BRACKET_GUARD_BYPASS_FLAG = '__skipBracketUnsavedGuard';
+
+const isBrowser = typeof window !== 'undefined';
+
+export const setBracketUnsavedChangesFlag = (hasUnsavedChanges) => {
+  if (!isBrowser) return;
+  window[BRACKET_UNSAVED_FLAG] = Boolean(hasUnsavedChanges);
+};
+
+export const clearBracketUnsavedChangesFlag = () => {
+  if (!isBrowser) return;
+  window[BRACKET_UNSAVED_FLAG] = false;
+  window[BRACKET_GUARD_BYPASS_FLAG] = false;
+};
+
+export const shouldWarnOnBracketExit = () => {
+  if (!isBrowser) return false;
+  return Boolean(window[BRACKET_UNSAVED_FLAG]) && !Boolean(window[BRACKET_GUARD_BYPASS_FLAG]);
+};
+
+export const confirmBracketExitIfNeeded = () => {
+  if (!isBrowser) return true;
+  if (!shouldWarnOnBracketExit()) return true;
+  return window.confirm(BRACKET_UNSAVED_EXIT_MESSAGE);
+};
+
+export const runWithBracketGuardBypass = async (callback) => {
+  if (!isBrowser) return callback();
+
+  const previousBypassState = window[BRACKET_GUARD_BYPASS_FLAG];
+  window[BRACKET_GUARD_BYPASS_FLAG] = true;
+  try {
+    return await callback();
+  } finally {
+    window[BRACKET_GUARD_BYPASS_FLAG] = previousBypassState;
+  }
+};


### PR DESCRIPTION
## Summary
- add unsaved-bracket navigation protection in BracketPage
- warn on browser refresh/close via `beforeunload`
- warn on in-app route changes via `useBlocker`
- migrate app routing to data router (`createBrowserRouter` + `RouterProvider`) so blockers are supported
- keep router instance stable to avoid post-SSO navigation stalls

## Validation
- pm.cmd run build passes
- manually verified Google SSO flow no longer hangs after account selection
- unsaved warning appears when leaving /bracket with unsaved picks

Closes #40 