### PR TITLE
feat: add eliminated bracket matchup state (#47)

### DIFF
--- a/src/components/BracketMatchup.jsx
+++ b/src/components/BracketMatchup.jsx
@@ -5,7 +5,7 @@ import { getLogoPath, getShortTeamName } from '../shared/teamUtils';
 
 function getMatchupResultState(m) {
   if (!m?.hasPick) return 'na';
-  if (m?.isMatchupExist === false && !m?.isPlayed) return 'eliminated';
+  if (m?.isMatchupExist === false) return 'eliminated';
   if (!m?.isPlayed) return 'pending';
 
   const isBullseye =
@@ -326,7 +326,7 @@ const BracketMatchup = ({ matchup: m, isLocked, isFinals, onMatchupClick }) => {
   const t1IsPredWinner = m.predWinnerIsTeam1;
   const t2IsPredWinner = m.predWinnerIsTeam2;
   const t1IsActualWinner = m.actualWinnerIsTeam1;
-  const t2IsActualWinner = m.isPlayed && !m.actualWinnerIsTeam1;
+  const t2IsActualWinner = m.actualWinnerIsTeam2;
 
   const showScoreBar = m.hasPick || m.isPlayed;
   const predictedWinnerTeamName = m.hasPick
@@ -339,9 +339,11 @@ const BracketMatchup = ({ matchup: m, isLocked, isFinals, onMatchupClick }) => {
   const predValue = m.isPlayin
     ? (m.hasPick ? getShortTeamName(predictedWinnerTeamName) : 'N/A')
     : (m.predicted_series_score || '-');
-  const actValue = m.isPlayin
-    ? (m.isPlayed ? getShortTeamName(actualWinnerTeamName) : null)
-    : (m.isPlayed ? m.actual_series_score : null);
+  const isEliminated = resultState === 'eliminated';
+  const actValue = isEliminated ? null
+    : m.isPlayin
+      ? (m.isPlayed ? getShortTeamName(actualWinnerTeamName) : null)
+      : (m.isPlayed ? m.actual_series_score : null);
   const resultChipLabel = actValue ? `${resultChip.label} • ${actValue}` : resultChip.label;
 
   return (

--- a/src/services/BracketServices.js
+++ b/src/services/BracketServices.js
@@ -31,6 +31,8 @@ function enrichMatchup(m) {
     predWinnerIsTeam2:   hasPick  && m.predicted_winner_team_id === m.team_2?.team_id,
     // true when the actual winner is team_1 (used to show result overlay)
     actualWinnerIsTeam1: isPlayed && m.actual_winner_team_id    === m.team_1?.team_id,
+    // true when the actual winner is team_2
+    actualWinnerIsTeam2: isPlayed && m.actual_winner_team_id    === m.team_2?.team_id,
     // TBD: either team slot is not yet determined (pre-play-in)
     isTbd: !m.team_1 || !m.team_2,
     // TODO(Phase 4): server returns is_correct (snake_case) — map it here so BracketMatchup


### PR DESCRIPTION
## Summary
- consume backend `is_matchup_exist` in bracket matchup enrichment
- show `Eliminated` when a predicted matchup never materializes
- add explanatory tooltip for matchup status chips
- configure tooltip interaction to work on touch devices and avoid opening the card when the chip is pressed
- fix predicted team-2 highlighting to use an explicit flag instead of fallback inversion

## Dependency
- depends on server PR darchock/NBA-Playoffs-Brackets-App-Server#72 exposing `is_matchup_exist` in `/bracket/get_player_bracket`

## Validation
- `npm.cmd run build`

Closes #47