### PR TITLE
Follow-up: cookie auth fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ import { PLAYER_AVATARS } from '../shared/GeneralConsts';
 - Do NOT use inline styles (`style={}`) — use MUI `sx` prop instead
 - Do NOT bypass `apiClient` for API calls
 - Do NOT add new CSS files — use MUI theming and `sx`
-- Do NOT store sensitive data in localStorage beyond auth tokens
+- Do NOT store sensitive data in localStorage (auth tokens now use httpOnly cookies)
 
 ---
 

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -190,9 +190,25 @@ export function AuthProvider({ children }) {
 
         while (retryCount <= MAX_RETRIES && !syncSucceeded) {
           try {
-            // Exchange Firebase token for session cookie via /auth/session-login.
-            // The server sets an httpOnly session cookie + CSRF token cookie automatically.
-            const userData = await UserServices.syncUserWithDatabase(user, retryCount);
+            let userData = null;
+            const hasCsrfCookie = document.cookie.includes('csrf_token=');
+
+            // If a session already exists (page reload), try lightweight check first
+            if (hasCsrfCookie) {
+              try {
+                userData = await UserServices.checkUserWithSession();
+              } catch (error) {
+                // If session is missing/invalid, fall back to session-login below
+                if (error.status !== 401 && error.status !== 403) {
+                  throw error;
+                }
+              }
+            }
+
+            if (!userData) {
+              // Exchange Firebase token for session cookie via /auth/session_login.
+              userData = await UserServices.syncUserWithDatabase(user, retryCount);
+            }
 
             // Set admin status from server response
             setIsAdmin(userData?.is_admin || false);

--- a/src/services/ApiClient.js
+++ b/src/services/ApiClient.js
@@ -1,3 +1,5 @@
+import { clearLocalStoragePreserveTheme } from '../utils/authStorage';
+
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
 
 /**
@@ -65,16 +67,7 @@ const apiClient = {
         try {
           console.log(`Auth error: ${errorMessage}`);
 
-          // Clear server session cookie (fire and forget)
-          fetch(`${API_BASE_URL}/auth/logout`, {
-            method: 'POST',
-            credentials: 'include',
-          }).catch(() => {});
-
-          // Save theme
-          const theme = localStorage.getItem('theme-mode');
-          localStorage.clear();
-          if (theme) localStorage.setItem('theme-mode', theme);
+          clearLocalStoragePreserveTheme();
 
           // Show notification first, before potential redirect
           if (window.notify) {

--- a/src/services/UserServices.js
+++ b/src/services/UserServices.js
@@ -1,4 +1,5 @@
 import apiClient from './ApiClient';
+import { clearLocalStoragePreserveTheme } from '../utils/authStorage';
 
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
 
@@ -8,7 +9,7 @@ const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
 const UserServices = {
   /**
    * Sync user with database after Firebase authentication.
-   * Exchanges a Firebase ID token for an httpOnly session cookie via /auth/session-login.
+   * Exchanges a Firebase ID token for an httpOnly session cookie via /auth/session_login.
    * The server sets the session cookie and a JS-readable CSRF token cookie automatically.
    * @param {Object} user - Firebase user object
    * @param {number} retryCount - Current retry attempt (for logging)
@@ -21,7 +22,7 @@ const UserServices = {
       // Get the Firebase ID token to exchange for a session cookie
       const idToken = await user.getIdToken();
 
-      const url = `${API_BASE_URL}/auth/session-login`;
+      const url = `${API_BASE_URL}/auth/session_login`;
       console.log(`Try fetching ${url} (attempt ${retryCount + 1})`);
 
       // Direct fetch (not apiClient) because this is the auth bootstrap —
@@ -45,6 +46,13 @@ const UserServices = {
       console.error("Error syncing user with database:", error);
       throw error;
     }
+  },
+
+  /**
+   * Lightweight auth check using existing cookies (no new session creation).
+   */
+  async checkUserWithSession() {
+    return apiClient.post('/user/check', {});
   },
   
   /**
@@ -95,9 +103,11 @@ const UserServices = {
    */
   async logout() {
     try {
+      const csrfToken = apiClient.getCookie('csrf_token');
       await fetch(`${API_BASE_URL}/auth/logout`, {
         method: 'POST',
         credentials: 'include',
+        headers: csrfToken ? { 'X-CSRF-Token': csrfToken } : {},
       });
     } catch (error) {
       // Log but don't throw — we still want to clear local state even if
@@ -105,12 +115,7 @@ const UserServices = {
       console.error("Error calling /auth/logout:", error);
     }
 
-    // Clear localStorage while preserving theme
-    const theme = localStorage.getItem('theme-mode');
-    localStorage.clear();
-    if (theme) {
-      localStorage.setItem('theme-mode', theme);
-    }
+    clearLocalStoragePreserveTheme();
   },
   
   /**
@@ -127,7 +132,7 @@ const UserServices = {
   },
 
   // storeUserData() removed — session cookie is set automatically by the browser
-  // from the /auth/session-login response. No localStorage token storage needed.
+  // from the /auth/session_login response. No localStorage token storage needed.
 };
 
 /**

--- a/src/utils/authStorage.js
+++ b/src/utils/authStorage.js
@@ -1,0 +1,10 @@
+/**
+ * Clear localStorage while preserving the user's theme preference.
+ */
+export function clearLocalStoragePreserveTheme() {
+  const theme = localStorage.getItem('theme-mode');
+  localStorage.clear();
+  if (theme) {
+    localStorage.setItem('theme-mode', theme);
+  }
+}


### PR DESCRIPTION
Post-merge follow-up for #57:
- Reuse existing sessions on reload via /user/check; only mint new session cookies when missing/invalid.
- Logout/401 handling share theme-preserving cleanup helper; /auth/logout sends CSRF.
- No auth tokens in localStorage; cookie-first flow.

These changes were committed after the original PR merge.

Related to server PR https://github.com/darchock/NBA-Playoffs-Brackets-App-Server/pull/82
Closes https://github.com/darchock/NBA-Playoffs-Brackets-App-Server/issues/76