### PR TITLE
Guard bracket editing before submissions open and fix mobile picker overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,10 @@ build/
 # Local-only verification files
 src/FirstLoginGuard.test.jsx
 src/components/AppExplanation.test.jsx
+src/components/bracket/BracketMatchup.test.jsx
 src/components/EditPicksDialog.test.jsx
 src/components/common/OnboardingDialogs.test.jsx
 src/pages/CreatePlayerPage.test.jsx
+src/pages/BracketPage.test.jsx
 src/pages/Dashboard.test.jsx
 src/utils/bracketUtils.test.js

--- a/src/components/EditPicksDialog.jsx
+++ b/src/components/EditPicksDialog.jsx
@@ -125,7 +125,6 @@ const EditPicksDialog = ({ open, onClose, type, player, onSave }) => {
     ? {
         openOnFocus: true,
         blurOnSelect: true,
-        disablePortal: true,
       }
     : {};
 

--- a/src/components/bracket/BracketMatchup.jsx
+++ b/src/components/bracket/BracketMatchup.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Box, Chip, Paper, Tooltip, Typography, useTheme } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { getLogoPath, getShortTeamName } from '../../shared/teamUtils';
@@ -248,34 +248,22 @@ function TeamRow({
 
 const BracketMatchup = ({ matchup: m, isLocked, isFinals, interactionHint, onMatchupClick, compact }) => {
   const theme = useTheme();
-  const hintTimeoutRef = useRef(null);
   const [isInteractionHintOpen, setIsInteractionHintOpen] = useState(false);
   const showInteractionHint = Boolean(interactionHint && m?.can_edit && !isLocked && !onMatchupClick);
 
-  useEffect(() => () => {
-    if (hintTimeoutRef.current) {
-      window.clearTimeout(hintTimeoutRef.current);
-    }
-  }, []);
+  // Auto-close the hint after 2.5 s. useEffect cleans up the timer if the hint
+  // closes early (via hideHint) or if the component unmounts.
+  useEffect(() => {
+    if (!isInteractionHintOpen) return undefined;
+    const id = window.setTimeout(() => setIsInteractionHintOpen(false), 2500);
+    return () => window.clearTimeout(id);
+  }, [isInteractionHintOpen]);
 
   const showHint = useCallback(() => {
-    if (!showInteractionHint) return;
-    if (hintTimeoutRef.current) {
-      window.clearTimeout(hintTimeoutRef.current);
-    }
-    setIsInteractionHintOpen(true);
-    hintTimeoutRef.current = window.setTimeout(() => {
-      setIsInteractionHintOpen(false);
-    }, 2500);
+    if (showInteractionHint) setIsInteractionHintOpen(true);
   }, [showInteractionHint]);
 
-  const hideHint = useCallback(() => {
-    if (hintTimeoutRef.current) {
-      window.clearTimeout(hintTimeoutRef.current);
-      hintTimeoutRef.current = null;
-    }
-    setIsInteractionHintOpen(false);
-  }, []);
+  const hideHint = useCallback(() => setIsInteractionHintOpen(false), []);
 
   if (!m) return null;
 
@@ -322,7 +310,7 @@ const BracketMatchup = ({ matchup: m, isLocked, isFinals, interactionHint, onMat
   const cardSx = {
     borderRadius: '10px',
     overflow: 'hidden',
-    opacity: m.isTbd ? 0.55 : isVoided ? 0.5 : 1,
+    opacity: m.isTbd ? 0.55 : isVoided ? 0.5 : showInteractionHint ? 0.6 : 1,
     cursor: isClickable ? 'pointer' : 'default',
     border: m.isTbd
       ? `1px dashed ${theme.palette.divider}`

--- a/src/components/bracket/BracketMatchup.jsx
+++ b/src/components/bracket/BracketMatchup.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Chip, Paper, Tooltip, Typography, useTheme } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { getLogoPath, getShortTeamName } from '../../shared/teamUtils';
@@ -246,8 +246,36 @@ function TeamRow({
   );
 }
 
-const BracketMatchup = ({ matchup: m, isLocked, isFinals, onMatchupClick, compact }) => {
+const BracketMatchup = ({ matchup: m, isLocked, isFinals, interactionHint, onMatchupClick, compact }) => {
   const theme = useTheme();
+  const hintTimeoutRef = useRef(null);
+  const [isInteractionHintOpen, setIsInteractionHintOpen] = useState(false);
+  const showInteractionHint = Boolean(interactionHint && m?.can_edit && !isLocked && !onMatchupClick);
+
+  useEffect(() => () => {
+    if (hintTimeoutRef.current) {
+      window.clearTimeout(hintTimeoutRef.current);
+    }
+  }, []);
+
+  const showHint = useCallback(() => {
+    if (!showInteractionHint) return;
+    if (hintTimeoutRef.current) {
+      window.clearTimeout(hintTimeoutRef.current);
+    }
+    setIsInteractionHintOpen(true);
+    hintTimeoutRef.current = window.setTimeout(() => {
+      setIsInteractionHintOpen(false);
+    }, 2500);
+  }, [showInteractionHint]);
+
+  const hideHint = useCallback(() => {
+    if (hintTimeoutRef.current) {
+      window.clearTimeout(hintTimeoutRef.current);
+      hintTimeoutRef.current = null;
+    }
+    setIsInteractionHintOpen(false);
+  }, []);
 
   if (!m) return null;
 
@@ -368,103 +396,125 @@ const BracketMatchup = ({ matchup: m, isLocked, isFinals, onMatchupClick, compac
     : undefined;
 
   return (
-    <Paper
-      elevation={0}
-      sx={cardSx}
-      onClick={isClickable ? () => onMatchupClick(m) : undefined}
-      onKeyDown={handleKeyDown}
-      tabIndex={isClickable ? 0 : undefined}
-      role={isClickable ? 'button' : undefined}
-      aria-label={isClickable ? `Predict ${m.team_1?.name || 'TBD'} vs ${m.team_2?.name || 'TBD'}` : undefined}
+    <Tooltip
+      title={showInteractionHint ? interactionHint : ''}
+      arrow
+      placement="top"
+      open={showInteractionHint ? isInteractionHintOpen : false}
+      disableFocusListener
+      disableHoverListener
+      disableTouchListener
+      enterTouchDelay={0}
+      leaveTouchDelay={2500}
     >
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: '9px', pt: '6px', pb: '2px' }}>
-        <Tooltip
-          title={resultTooltip}
-          arrow
-          placement="top"
-          describeChild
-          enterTouchDelay={0}
-          leaveTouchDelay={3500}
+      <Box
+        component="span"
+        sx={{ display: 'block' }}
+        onMouseEnter={showInteractionHint ? showHint : undefined}
+        onMouseLeave={showInteractionHint ? hideHint : undefined}
+        onFocus={showInteractionHint ? showHint : undefined}
+        onBlur={showInteractionHint ? hideHint : undefined}
+        onClick={showInteractionHint ? showHint : undefined}
+      >
+        <Paper
+          elevation={0}
+          sx={cardSx}
+          onClick={isClickable ? () => onMatchupClick(m) : undefined}
+          onKeyDown={handleKeyDown}
+          tabIndex={isClickable ? 0 : undefined}
+          role={isClickable ? 'button' : undefined}
+          aria-label={isClickable ? `Predict ${m.team_1?.name || 'TBD'} vs ${m.team_2?.name || 'TBD'}` : undefined}
         >
-          <Box
-            component="span"
-            sx={{ display: 'inline-flex' }}
-            onClick={(event) => event.stopPropagation()}
-            onMouseDown={(event) => event.stopPropagation()}
-            onTouchStart={(event) => event.stopPropagation()}
-          >
-            <Chip
-              size="small"
-              variant="outlined"
-              label={resultChipLabel}
-              sx={{
-                height: 18,
-                fontSize: '0.625rem',
-                fontWeight: 700,
-                letterSpacing: '0.02em',
-                '& .MuiChip-label': { px: '6px' },
-                ...resultChip.sx,
-              }}
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: '9px', pt: '6px', pb: '2px' }}>
+            <Tooltip
+              title={resultTooltip}
+              arrow
+              placement="top"
+              describeChild
+              enterTouchDelay={0}
+              leaveTouchDelay={3500}
+            >
+              <Box
+                component="span"
+                sx={{ display: 'inline-flex' }}
+                onClick={(event) => event.stopPropagation()}
+                onMouseDown={(event) => event.stopPropagation()}
+                onTouchStart={(event) => event.stopPropagation()}
+              >
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  label={resultChipLabel}
+                  sx={{
+                    height: 18,
+                    fontSize: '0.625rem',
+                    fontWeight: 700,
+                    letterSpacing: '0.02em',
+                    '& .MuiChip-label': { px: '6px' },
+                    ...resultChip.sx,
+                  }}
+                />
+              </Box>
+            </Tooltip>
+          </Box>
+          <TeamRow
+            team={m.team_1}
+            seed={m.team_1?.seed}
+            isPredWinner={t1IsPredWinner}
+            isActualWinner={t1IsActualWinner}
+            hasPick={m.hasPick}
+            isPlayed={isLocked && m.isPlayed}
+            isMiss={isMiss}
+            isVoided={isVoided}
+            isEliminated={isLocked && m.team_1?.is_active === false && !t1IsActualWinner}
+            compact={compact}
+            showWinnerIndicator={isLocked && m.isPlayed && t1IsActualWinner}
+          />
+          <Box sx={{ borderTop: `1px solid ${theme.palette.divider}` }}>
+            <TeamRow
+              team={m.team_2}
+              seed={m.team_2?.seed}
+              isPredWinner={t2IsPredWinner}
+              isActualWinner={t2IsActualWinner}
+              hasPick={m.hasPick}
+              isPlayed={isLocked && m.isPlayed}
+              isMiss={isMiss}
+              isVoided={isVoided}
+              isEliminated={isLocked && m.team_2?.is_active === false && !t2IsActualWinner}
+              compact={compact}
+              showWinnerIndicator={isLocked && m.isPlayed && t2IsActualWinner}
             />
           </Box>
-        </Tooltip>
-      </Box>
-      <TeamRow
-        team={m.team_1}
-        seed={m.team_1?.seed}
-        isPredWinner={t1IsPredWinner}
-        isActualWinner={t1IsActualWinner}
-        hasPick={m.hasPick}
-        isPlayed={isLocked && m.isPlayed}
-        isMiss={isMiss}
-        isVoided={isVoided}
-        isEliminated={isLocked && m.team_1?.is_active === false && !t1IsActualWinner}
-        compact={compact}
-        showWinnerIndicator={isLocked && m.isPlayed && t1IsActualWinner}
-      />
-      <Box sx={{ borderTop: `1px solid ${theme.palette.divider}` }}>
-        <TeamRow
-          team={m.team_2}
-          seed={m.team_2?.seed}
-          isPredWinner={t2IsPredWinner}
-          isActualWinner={t2IsActualWinner}
-          hasPick={m.hasPick}
-          isPlayed={isLocked && m.isPlayed}
-          isMiss={isMiss}
-          isVoided={isVoided}
-          isEliminated={isLocked && m.team_2?.is_active === false && !t2IsActualWinner}
-          compact={compact}
-          showWinnerIndicator={isLocked && m.isPlayed && t2IsActualWinner}
-        />
-      </Box>
 
-      {showScoreBar && scoreBarText && (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '3px',
-            px: '9px',
-            py: '3px',
-            background: alpha(theme.palette.text.primary, 0.06),
-            borderTop: `1px solid ${theme.palette.divider}`,
-          }}
-        >
-          <Typography
-            component="span"
-            sx={{ fontSize: '0.625rem', fontWeight: 400, opacity: 0.7, color: theme.palette.text.secondary }}
-          >
-            Prediction:
-          </Typography>
-          <Typography
-            component="span"
-            sx={{ fontSize: '0.625rem', fontWeight: 700, color: theme.palette.text.secondary }}
-          >
-            {predictedWinnerName}{m.predicted_series_score ? ` ${m.predicted_series_score}` : ''}
-          </Typography>
-        </Box>
-      )}
-    </Paper>
+          {showScoreBar && scoreBarText && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '3px',
+                px: '9px',
+                py: '3px',
+                background: alpha(theme.palette.text.primary, 0.06),
+                borderTop: `1px solid ${theme.palette.divider}`,
+              }}
+            >
+              <Typography
+                component="span"
+                sx={{ fontSize: '0.625rem', fontWeight: 400, opacity: 0.7, color: theme.palette.text.secondary }}
+              >
+                Prediction:
+              </Typography>
+              <Typography
+                component="span"
+                sx={{ fontSize: '0.625rem', fontWeight: 700, color: theme.palette.text.secondary }}
+              >
+                {predictedWinnerName}{m.predicted_series_score ? ` ${m.predicted_series_score}` : ''}
+              </Typography>
+            </Box>
+          )}
+        </Paper>
+      </Box>
+    </Tooltip>
   );
 };
 

--- a/src/components/bracket/BracketView.jsx
+++ b/src/components/bracket/BracketView.jsx
@@ -24,6 +24,30 @@ function formatCountdown(ms) {
   return `${mins}m`;
 }
 
+function formatPredictionsOpenLabel(dateString) {
+  if (!dateString) return null;
+  const parsed = new Date(dateString);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  const parts = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'Asia/Jerusalem',
+  }).formatToParts(parsed);
+
+  const month = parts.find(part => part.type === 'month')?.value;
+  const day = parts.find(part => part.type === 'day')?.value;
+  const hour = parts.find(part => part.type === 'hour')?.value;
+  const minute = parts.find(part => part.type === 'minute')?.value;
+  const dayPeriod = parts.find(part => part.type === 'dayPeriod')?.value;
+
+  if (!month || !day || !hour || !minute || !dayPeriod) return null;
+  return `${month} ${day}, ${hour}:${minute} ${dayPeriod}`;
+}
+
 /**
  * BracketHeader - adapts between write mode (progress bar + countdown) and
  * read mode (health stats + accuracy bar + viewing badge).
@@ -33,6 +57,7 @@ function BracketHeader({
   totalMatchups,
   isLocked,
   deadline,
+  predictionsOpenDate,
   bracketHealth,
   viewingPlayerName,
   actionButtons,
@@ -290,9 +315,16 @@ function BracketHeader({
     ? Math.round((predictedMatchups / totalMatchups) * 100)
     : 0;
 
+  const openDate = predictionsOpenDate ? new Date(predictionsOpenDate) : null;
+  const isPredictionsOpen = !openDate || now >= openDate.getTime();
+  const openDateLabel = formatPredictionsOpenLabel(predictionsOpenDate);
+
   let deadlineLabel = null;
   let deadlineColor = 'text.secondary';
-  if (isLocked) {
+  if (!isPredictionsOpen) {
+    deadlineLabel = openDateLabel ? `\u23F3 Submissions open ${openDateLabel}` : '\u23F3 Submissions not yet open';
+    deadlineColor = 'text.secondary';
+  } else if (isLocked) {
     deadlineLabel = lockedDateLabel ? `\uD83D\uDD12 Bracket locked on ${lockedDateLabel}` : '\uD83D\uDD12 Bracket locked';
     deadlineColor = 'error.main';
   } else if (countdownStr) {
@@ -367,6 +399,8 @@ const BracketView = ({
   predictedMatchups,
   totalMatchups,
   deadline,
+  predictionsOpenDate,
+  interactionHint,
   onMatchupClick,
   bracketHealth,
   viewingPlayerName,
@@ -387,6 +421,7 @@ const BracketView = ({
       totalMatchups={totalMatchups}
       isLocked={isLocked}
       deadline={deadline}
+      predictionsOpenDate={predictionsOpenDate}
       bracketHealth={bracketHealth}
       viewingPlayerName={viewingPlayerName}
       actionButtons={actionButtons}
@@ -411,6 +446,7 @@ const BracketView = ({
         <MobileBracketScroll
           bracket={bracket}
           isLocked={isLocked}
+          interactionHint={interactionHint}
           onMatchupClick={onMatchupClick}
           bonusPicks={bonusPicks}
           scoringConfig={scoringConfig}
@@ -428,6 +464,7 @@ const BracketView = ({
         <DesktopBracketGrid
           bracket={bracket}
           isLocked={isLocked}
+          interactionHint={interactionHint}
           onMatchupClick={onMatchupClick}
           bonusPicks={bonusPicks}
           scoringConfig={scoringConfig}

--- a/src/components/bracket/DesktopBracketGrid.jsx
+++ b/src/components/bracket/DesktopBracketGrid.jsx
@@ -127,7 +127,7 @@ function RoundHeader({ label, pts, variant, gridColumn }) {
  * 15-column, 9-row grid: West play-in | West R1-Semis-CF | Finals | East CF-Semis-R1 | East play-in
  * Includes connector lines and hover path highlighting.
  */
-const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, scoringConfig }) => {
+const DesktopBracketGrid = ({ bracket, isLocked, interactionHint, onMatchupClick, bonusPicks, scoringConfig }) => {
   const theme = useTheme();
   const gridRef = useRef(null);
   const animatedRef = useRef(false);
@@ -288,7 +288,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
               </Box>
             </Tooltip>
             <HoverCard data-card-id="w-surv" data-feeds="w-pi-1,w-pi-2" delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}>
-              <BracketMatchup matchup={westSurvivor} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+              <BracketMatchup matchup={westSurvivor} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
             </HoverCard>
           </>
         )}
@@ -298,7 +298,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
               {m.matchup_position === 1 ? '#7 vs #8' : '#9 vs #10'}
             </Typography>
             <HoverCard data-card-id={`w-pi-${m.matchup_position}`} data-feeds="" delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}>
-              <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+              <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
             </HoverCard>
           </React.Fragment>
         ))}
@@ -317,7 +317,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
             delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}
             sx={{ gridColumn: 3, gridRow: rows[i], px: '2px' }}
           >
-            <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+            <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
           </HoverCard>
         );
       })}
@@ -334,7 +334,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
           delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}
           sx={{ gridColumn: 5, gridRow: '3 / 6', px: '2px', alignSelf: 'center' }}
         >
-          <BracketMatchup matchup={westSemis[0]} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+          <BracketMatchup matchup={westSemis[0]} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
         </HoverCard>
       )}
       {westSemis[1] && (
@@ -344,7 +344,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
           delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}
           sx={{ gridColumn: 5, gridRow: '7 / 10', px: '2px', alignSelf: 'center' }}
         >
-          <BracketMatchup matchup={westSemis[1]} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+          <BracketMatchup matchup={westSemis[1]} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
         </HoverCard>
       )}
 
@@ -359,7 +359,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
           delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}
           sx={{ gridColumn: 7, gridRow: '3 / 10', px: '2px', alignSelf: 'center' }}
         >
-          <BracketMatchup matchup={westCf} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+          <BracketMatchup matchup={westCf} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
         </HoverCard>
       )}
 
@@ -413,7 +413,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
           sx={{ width: '100%' }}
         >
           {/* Finals card: full team names (no compact) — wider column gives room */}
-          <BracketMatchup matchup={bracket.final} isLocked={isLocked} isFinals onMatchupClick={onMatchupClick} />
+          <BracketMatchup matchup={bracket.final} isLocked={isLocked} interactionHint={interactionHint} isFinals onMatchupClick={onMatchupClick} />
         </HoverCard>
         {bonusPicks && (
           <Box sx={{ width: '100%', mt: '16px' }}>
@@ -443,7 +443,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
           delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}
           sx={{ gridColumn: 11, gridRow: '3 / 10', px: '2px', alignSelf: 'center' }}
         >
-          <BracketMatchup matchup={eastCf} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+          <BracketMatchup matchup={eastCf} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
         </HoverCard>
       )}
 
@@ -458,7 +458,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
           delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}
           sx={{ gridColumn: 13, gridRow: '3 / 6', px: '2px', alignSelf: 'center' }}
         >
-          <BracketMatchup matchup={eastSemis[0]} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+          <BracketMatchup matchup={eastSemis[0]} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
         </HoverCard>
       )}
       {eastSemis[1] && (
@@ -468,7 +468,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
           delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}
           sx={{ gridColumn: 13, gridRow: '7 / 10', px: '2px', alignSelf: 'center' }}
         >
-          <BracketMatchup matchup={eastSemis[1]} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+          <BracketMatchup matchup={eastSemis[1]} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
         </HoverCard>
       )}
 
@@ -489,7 +489,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
             delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}
             sx={{ gridColumn: 15, gridRow: rows[i], px: '2px' }}
           >
-            <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+            <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
           </HoverCard>
         );
       })}
@@ -513,7 +513,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
               </Box>
             </Tooltip>
             <HoverCard data-card-id="e-surv" data-feeds="e-pi-1,e-pi-2" delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}>
-              <BracketMatchup matchup={eastSurvivor} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+              <BracketMatchup matchup={eastSurvivor} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
             </HoverCard>
           </>
         )}
@@ -523,7 +523,7 @@ const DesktopBracketGrid = ({ bracket, isLocked, onMatchupClick, bonusPicks, sco
               {m.matchup_position === 1 ? '#7 vs #8' : '#9 vs #10'}
             </Typography>
             <HoverCard data-card-id={`e-pi-${m.matchup_position}`} data-feeds="" delay={skipDelay ? undefined : cardIdx++ * 40} onHoverStart={handleMouseEnter} onHoverEnd={handleMouseLeave}>
-              <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} compact />
+              <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} compact />
             </HoverCard>
           </React.Fragment>
         ))}

--- a/src/components/bracket/MobileBracketScroll.jsx
+++ b/src/components/bracket/MobileBracketScroll.jsx
@@ -74,7 +74,7 @@ function ConferenceSection({ title, children, defaultExpanded = true }) {
  * Play-in section with fork connector showing Survivor → PI-1/PI-2 relationship.
  * `conference` is 'w' or 'e' — used for tap-to-highlight card IDs.
  */
-function PlayinSection({ survivor, playinGames, isLocked, onMatchupClick, conference, onTap, cardIdx, skipDelay }) {
+function PlayinSection({ survivor, playinGames, isLocked, interactionHint, onMatchupClick, conference, onTap, cardIdx, skipDelay }) {
   const theme = useTheme();
   const connColor = alpha(theme.palette.warning.main, 0.4);
   const c = conference;
@@ -96,7 +96,7 @@ function PlayinSection({ survivor, playinGames, isLocked, onMatchupClick, confer
             </Box>
           </Tooltip>
           <TappableCard data-card-id={`${c}-surv`} data-feeds={`${c}-pi-1,${c}-pi-2`} delay={skipDelay ? undefined : cardIdx.val++ * 40} onTap={onTap}>
-            <BracketMatchup matchup={survivor} isLocked={isLocked} onMatchupClick={onMatchupClick} />
+            <BracketMatchup matchup={survivor} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} />
           </TappableCard>
         </Box>
       )}
@@ -137,7 +137,7 @@ function PlayinSection({ survivor, playinGames, isLocked, onMatchupClick, confer
             {m.matchup_position === 1 ? '#7 vs #8' : '#9 vs #10'}
           </Typography>
           <TappableCard data-card-id={`${c}-pi-${m.matchup_position}`} data-feeds="" delay={skipDelay ? undefined : cardIdx.val++ * 40} onTap={onTap}>
-            <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} />
+            <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} />
           </TappableCard>
         </Box>
       ))}
@@ -277,7 +277,7 @@ function TappableCard({ children, delay, onTap, sx: sxProp, ...props }) {
  * 5 round columns: Play-In, R1, Semis, Conf Finals, Finals.
  * Each column has collapsible West/East sections.
  */
-const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, scoringConfig, inDialog = false }) => {
+const MobileBracketScroll = ({ bracket, isLocked, interactionHint, onMatchupClick, bonusPicks, scoringConfig, inDialog = false }) => {
   const theme = useTheme();
   const scrollRef = useRef(null);
   const colRefs = useRef([]);
@@ -392,7 +392,8 @@ const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, sc
   };
 
   return (
-    <Box sx={{ position: 'relative' }}>
+    <>
+      <Box sx={{ position: 'relative' }}>
       {/* Swipe hint — fades out after 3s or on first scroll */}
       <Box sx={{
         position: 'absolute', top: '50%', right: 8, transform: 'translateY(-50%)',
@@ -433,6 +434,7 @@ const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, sc
               survivor={(west.survivor || [])[0]}
               playinGames={west.playin || []}
               isLocked={isLocked}
+              interactionHint={interactionHint}
               onMatchupClick={onMatchupClick}
               conference="w"
               onTap={handleCardTap}
@@ -445,6 +447,7 @@ const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, sc
               survivor={(east.survivor || [])[0]}
               playinGames={east.playin || []}
               isLocked={isLocked}
+              interactionHint={interactionHint}
               onMatchupClick={onMatchupClick}
               conference="e"
               onTap={handleCardTap}
@@ -464,7 +467,7 @@ const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, sc
               return (
                 <React.Fragment key={m.matchup_position}>
                   <TappableCard data-card-id={`w-r1-${m.matchup_position}`} data-feeds={feeds} delay={skipDelay ? undefined : cardIdx.val++ * 40} onTap={handleCardTap} sx={{ mb: 1 }}>
-                    <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} />
+                    <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} />
                   </TappableCard>
                   {i === 2 && arr.length > 2 && <FlowLabel text={'\u2192 Western Semi-Final 2'} />}
                   {i === 0 && <FlowLabel text={'\u2192 Western Semi-Final 1'} />}
@@ -479,7 +482,7 @@ const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, sc
               return (
                 <React.Fragment key={m.matchup_position}>
                   <TappableCard data-card-id={`e-r1-${m.matchup_position}`} data-feeds={feeds} delay={skipDelay ? undefined : cardIdx.val++ * 40} onTap={handleCardTap} sx={{ mb: 1 }}>
-                    <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} />
+                    <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} />
                   </TappableCard>
                   {i === 2 && arr.length > 2 && <FlowLabel text={'\u2192 Eastern Semi-Final 2'} />}
                   {i === 0 && <FlowLabel text={'\u2192 Eastern Semi-Final 1'} />}
@@ -496,7 +499,7 @@ const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, sc
             {(west.semis || []).sort((a, b) => a.matchup_position - b.matchup_position).map((m, i) => (
               <React.Fragment key={m.matchup_position}>
                 <TappableCard data-card-id={`w-s${m.matchup_position}`} data-feeds={m.matchup_position === 1 ? 'w-r1-1,w-r1-4' : 'w-r1-3,w-r1-2'} delay={skipDelay ? undefined : cardIdx.val++ * 40} onTap={handleCardTap} sx={{ mb: 1 }}>
-                  <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} />
+                  <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} />
                 </TappableCard>
                 {i === 0 && <FlowLabel text={'\u2192 Western Conference Final'} accent />}
               </React.Fragment>
@@ -506,7 +509,7 @@ const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, sc
             {(east.semis || []).sort((a, b) => a.matchup_position - b.matchup_position).map((m, i) => (
               <React.Fragment key={m.matchup_position}>
                 <TappableCard data-card-id={`e-s${m.matchup_position}`} data-feeds={m.matchup_position === 1 ? 'e-r1-1,e-r1-4' : 'e-r1-3,e-r1-2'} delay={skipDelay ? undefined : cardIdx.val++ * 40} onTap={handleCardTap} sx={{ mb: 1 }}>
-                  <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} />
+                  <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} />
                 </TappableCard>
                 {i === 0 && <FlowLabel text={'\u2192 Eastern Conference Final'} accent />}
               </React.Fragment>
@@ -520,14 +523,14 @@ const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, sc
           <ConferenceSection title="Western Conference">
             {(west.cf || []).map(m => (
               <TappableCard key={m.matchup_position} data-card-id="w-cf" data-feeds="w-s1,w-s2" delay={skipDelay ? undefined : cardIdx.val++ * 40} onTap={handleCardTap} sx={{ mb: 1 }}>
-                <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} />
+                <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} />
               </TappableCard>
             ))}
           </ConferenceSection>
           <ConferenceSection title="Eastern Conference">
             {(east.cf || []).map(m => (
               <TappableCard key={m.matchup_position} data-card-id="e-cf" data-feeds="e-s1,e-s2" delay={skipDelay ? undefined : cardIdx.val++ * 40} onTap={handleCardTap} sx={{ mb: 1 }}>
-                <BracketMatchup matchup={m} isLocked={isLocked} onMatchupClick={onMatchupClick} />
+                <BracketMatchup matchup={m} isLocked={isLocked} interactionHint={interactionHint} onMatchupClick={onMatchupClick} />
               </TappableCard>
             ))}
           </ConferenceSection>
@@ -545,7 +548,7 @@ const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, sc
             </Typography>
           </Box>
           <TappableCard data-card-id="final" data-feeds="w-cf,e-cf" delay={skipDelay ? undefined : cardIdx.val++ * 40} onTap={handleCardTap} sx={{ mb: 1 }}>
-            <BracketMatchup matchup={bracket.final} isLocked={isLocked} isFinals onMatchupClick={onMatchupClick} />
+            <BracketMatchup matchup={bracket.final} isLocked={isLocked} interactionHint={interactionHint} isFinals onMatchupClick={onMatchupClick} />
           </TappableCard>
           {bonusPicks && (
             <BonusPicks {...bonusPicks} isLocked={isLocked} />
@@ -553,12 +556,14 @@ const MobileBracketScroll = ({ bracket, isLocked, onMatchupClick, bonusPicks, sc
         </Box>
       </Box>
 
+      </Box>
+
       {/* Dot navigation — portaled to body so position:fixed works regardless of ancestor transforms */}
       {createPortal(
         <DotNav count={5} activeIndex={activeRound} onDotClick={scrollToRound} zIndex={inDialog ? theme.zIndex.modal + 100 : 10} />,
         document.body,
       )}
-    </Box>
+    </>
   );
 };
 

--- a/src/pages/BracketPage.jsx
+++ b/src/pages/BracketPage.jsx
@@ -180,7 +180,7 @@ const BracketPage = () => {
 
     const timeoutId = window.setTimeout(
       () => setNow(Date.now()),
-      Math.min(...pendingTransitions) - now,
+      Math.max(0, Math.min(...pendingTransitions) - now),
     );
 
     return () => window.clearTimeout(timeoutId);
@@ -311,7 +311,7 @@ const BracketPage = () => {
         bracket: bracketState,
         bonusPicks,
         scoringConfig: bracketState.scoringConfig,
-        isLocked: bracketState.isLocked,
+        isLocked: isBracketLocked,
         playerName: activePlayer.player_name,
         leagueName: activePlayer.league_name,
         themeMode,

--- a/src/pages/BracketPage.jsx
+++ b/src/pages/BracketPage.jsx
@@ -24,6 +24,7 @@ import PredictionDialog from '../components/bracket/PredictionDialog';
 import LeagueBracketsDialog from '../components/bracket/LeagueBracketsDialog';
 import BracketServices from '../services/BracketServices';
 import { applyPick, countPicks, picksMatch, flattenBracketPicks, computeBracketHealth, randomFillBracket, clearAllPicks } from '../utils/bracketUtils';
+import { PREDICTIONS_OPEN_DATE } from '../shared/SeasonConfig';
 import { captureBracketImage, downloadBracketImage, shareBracketImage, copyBracketImage } from '../utils/bracketExport';
 
 // PredictionDialog passes matchup.round (API key: 'playin_first', 'first', etc.)
@@ -37,6 +38,30 @@ const API_TO_COMPONENT_ROUND = {
   final:             'final',
 };
 
+function formatPredictionsOpenText(dateString) {
+  if (!dateString) return null;
+  const parsed = new Date(dateString);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  const parts = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'Asia/Jerusalem',
+  }).formatToParts(parsed);
+
+  const month = parts.find(part => part.type === 'month')?.value;
+  const day = parts.find(part => part.type === 'day')?.value;
+  const hour = parts.find(part => part.type === 'hour')?.value;
+  const minute = parts.find(part => part.type === 'minute')?.value;
+  const dayPeriod = parts.find(part => part.type === 'dayPeriod')?.value;
+
+  if (!month || !day || !hour || !minute || !dayPeriod) return null;
+  return `${month} ${day} at ${hour}:${minute} ${dayPeriod} Jerusalem time`;
+}
+
 const BracketPage = () => {
   // serverBracket: last confirmed server state — used to detect unsaved changes
   // bracketState:  live working copy that diverges from serverBracket during editing
@@ -44,6 +69,7 @@ const BracketPage = () => {
   const [bracketState, setBracketState]   = useState(null);
   const [loading, setLoading]             = useState(true);
   const [error, setError]                 = useState(null);
+  const [now, setNow]                     = useState(() => Date.now());
 
   // Dialog state
   const [dialogOpen, setDialogOpen]           = useState(false);
@@ -121,13 +147,60 @@ const BracketPage = () => {
     };
   }, [bracketState]);
 
+  const predictionsOpenDate = bracketState?.predictionsOpenDate ?? PREDICTIONS_OPEN_DATE.toISOString();
+  const predictionsOpenAt = useMemo(() => {
+    const parsed = Date.parse(predictionsOpenDate);
+    return Number.isNaN(parsed) ? null : parsed;
+  }, [predictionsOpenDate]);
+  const predictionsOpenLabel = useMemo(
+    () => formatPredictionsOpenText(predictionsOpenDate),
+    [predictionsOpenDate],
+  );
+  const deadlineAt = useMemo(() => {
+    if (!bracketState?.deadline) return null;
+    const parsed = Date.parse(bracketState.deadline);
+    return Number.isNaN(parsed) ? null : parsed;
+  }, [bracketState?.deadline]);
+  const isPredictionsOpen = predictionsOpenAt === null || now >= predictionsOpenAt;
+  const isBracketLocked = Boolean(
+    bracketState?.isLocked || (deadlineAt !== null && now >= deadlineAt)
+  );
+  const isEditingEnabled = Boolean(bracketState && !isBracketLocked && isPredictionsOpen);
+  const preOpenMessage = predictionsOpenLabel
+    ? `Bracket submissions open ${predictionsOpenLabel}, after the regular season ends.`
+    : 'Bracket submissions open after the regular season ends.';
+  const preOpenInteractionHint = !isPredictionsOpen && !isBracketLocked ? preOpenMessage : null;
+
+  useEffect(() => {
+    if (!bracketState) return undefined;
+
+    const pendingTransitions = [predictionsOpenAt, deadlineAt]
+      .filter(timestamp => timestamp !== null && now < timestamp);
+    if (pendingTransitions.length === 0) return undefined;
+
+    const timeoutId = window.setTimeout(
+      () => setNow(Date.now()),
+      Math.min(...pendingTransitions) - now,
+    );
+
+    return () => window.clearTimeout(timeoutId);
+  }, [bracketState, predictionsOpenAt, deadlineAt, now]);
+
   const hasUnsavedChanges = useMemo(() => {
-    if (!bracketState || bracketState.isLocked) return false;
+    if (!bracketState || isBracketLocked) return false;
     // Never-submitted bracket: any pick counts as unsaved
     if (!bracketState.isBracketSubmitted) return predictedCount > 0;
     // Submitted bracket: unsaved when React state differs from server snapshot
     return !picksMatch(bracketState, serverBracket);
-  }, [bracketState, serverBracket, predictedCount]);
+  }, [bracketState, isBracketLocked, serverBracket, predictedCount]);
+
+  useEffect(() => {
+    if (!isEditingEnabled) {
+      setDialogOpen(false);
+      setRandomFillAnchor(null);
+      setConfirmFillOpen(false);
+    }
+  }, [isEditingEnabled]);
 
   // -------------------------------------------------------------------------
   // Navigation guard — tab close / browser back button
@@ -147,11 +220,13 @@ const BracketPage = () => {
   // Handlers
   // -------------------------------------------------------------------------
   const handleMatchupClick = useCallback((matchup) => {
+    if (!isEditingEnabled) return;
     setSelectedMatchup(matchup);
     setDialogOpen(true);
-  }, []);
+  }, [isEditingEnabled]);
 
   const handlePredictWinner = (round, conference, matchupPosition, winnerTeamId, seriesScoreLoser) => {
+    if (!isEditingEnabled) return;
     const roundKey = API_TO_COMPONENT_ROUND[round] ?? round;
     setBracketState(prev =>
       applyPick(prev, { round: roundKey, conference, matchupPosition, winnerTeamId, seriesScoreLoser })
@@ -160,7 +235,7 @@ const BracketPage = () => {
   };
 
   const handleSubmitBracket = async () => {
-    if (!isComplete || submitting) return;
+    if (!isComplete || submitting || !isPredictionsOpen || isBracketLocked) return;
     setSubmitting(true);
     try {
       const picks  = flattenBracketPicks(bracketState);
@@ -182,7 +257,7 @@ const BracketPage = () => {
       if (window.notify) {
         window.notify.error(
           err?.status === 423
-            ? 'Bracket is locked — the deadline has passed.'
+            ? (err.message || 'Bracket submission is not available.')
             : 'Failed to submit bracket. Please try again.',
         );
       }
@@ -195,6 +270,7 @@ const BracketPage = () => {
   // Random fill handlers
   // -------------------------------------------------------------------------
   const handleRandomFill = useCallback((mode, strategy = 'random') => {
+    if (!isEditingEnabled) return;
     setRandomFillAnchor(null);
     if (mode === 'clear') {
       if (predictedCount > 0) {
@@ -209,16 +285,17 @@ const BracketPage = () => {
       return;
     }
     setBracketState(prev => randomFillBracket(prev, mode, strategy));
-  }, [predictedCount]);
+  }, [isEditingEnabled, predictedCount]);
 
   const handleConfirmFillAll = useCallback(() => {
+    if (!isEditingEnabled) return;
     setConfirmFillOpen(false);
     if (pendingStrategy === 'clear') {
       setBracketState(prev => clearAllPicks(prev));
     } else {
       setBracketState(prev => randomFillBracket(prev, 'all', pendingStrategy));
     }
-  }, [pendingStrategy]);
+  }, [isEditingEnabled, pendingStrategy]);
 
   // -------------------------------------------------------------------------
   // Share / export handlers
@@ -315,11 +392,13 @@ const BracketPage = () => {
       {/* Bracket display */}
       <BracketView
         bracket={bracketState}
-        isLocked={bracketState.isLocked}
+        isLocked={isBracketLocked}
         predictedMatchups={predictedCount}
         totalMatchups={bracketState.totalMatchups}
         deadline={bracketState.deadline}
-        onMatchupClick={bracketState.isLocked ? undefined : handleMatchupClick}
+        predictionsOpenDate={predictionsOpenDate}
+        interactionHint={preOpenInteractionHint}
+        onMatchupClick={isEditingEnabled ? handleMatchupClick : undefined}
         bracketHealth={bracketHealth}
         bonusPicks={bonusPicks}
         scoringConfig={bracketState.scoringConfig}
@@ -350,7 +429,7 @@ const BracketPage = () => {
               </Button>
             )}
 
-            {bracketState.isLocked && (
+            {isBracketLocked && (
               <Button
                 variant="outlined"
                 size="medium"
@@ -360,36 +439,46 @@ const BracketPage = () => {
                 League Brackets
               </Button>
             )}
-            {!bracketState.isLocked && (
+            {!isBracketLocked && (
               <>
-                {isMobile ? (
-                  <Tooltip title="Random Fill">
-                    <IconButton
+                {isPredictionsOpen && (
+                  isMobile ? (
+                    <Tooltip title="Random Fill">
+                      <IconButton
+                        onClick={(e) => setRandomFillAnchor(e.currentTarget)}
+                        color="primary"
+                      >
+                        <CasinoIcon />
+                      </IconButton>
+                    </Tooltip>
+                  ) : (
+                    <Button
+                      variant="outlined"
+                      size="medium"
                       onClick={(e) => setRandomFillAnchor(e.currentTarget)}
-                      color="primary"
+                      startIcon={<CasinoIcon />}
                     >
-                      <CasinoIcon />
-                    </IconButton>
-                  </Tooltip>
-                ) : (
-                  <Button
-                    variant="outlined"
-                    size="medium"
-                    onClick={(e) => setRandomFillAnchor(e.currentTarget)}
-                    startIcon={<CasinoIcon />}
-                  >
-                    Random Fill
-                  </Button>
+                      Random Fill
+                    </Button>
+                  )
                 )}
-                <Button
-                  variant="contained"
-                  size="medium"
-                  onClick={handleSubmitBracket}
-                  disabled={!isComplete || submitting || isSubmitted}
-                  startIcon={submitIcon}
+                <Tooltip
+                  title={!isPredictionsOpen ? preOpenMessage : ''}
+                  enterTouchDelay={0}
+                  leaveTouchDelay={2000}
                 >
-                  {submitLabel}
-                </Button>
+                  <span>
+                    <Button
+                      variant="contained"
+                      size="medium"
+                      onClick={handleSubmitBracket}
+                      disabled={!isComplete || submitting || isSubmitted || !isEditingEnabled}
+                      startIcon={submitIcon}
+                    >
+                      {submitLabel}
+                    </Button>
+                  </span>
+                </Tooltip>
               </>
             )}
           </>

--- a/src/services/BracketServices.js
+++ b/src/services/BracketServices.js
@@ -79,6 +79,7 @@ function transformBracketData(apiResponse) {
     predictedMatchups:   apiResponse.predicted_matchups ?? apiResponse.total_matchups,
     totalMatchups:       apiResponse.total_matchups,
     deadline:            apiResponse.deadline,
+    predictionsOpenDate: apiResponse.predictions_open_date ?? null,
     isLocked:            apiResponse.is_locked,
     isActualBracket,
     east:  groupByRound(apiResponse.conferences.east, isActualBracket),

--- a/src/shared/SeasonConfig.js
+++ b/src/shared/SeasonConfig.js
@@ -1,7 +1,9 @@
-// Season-level configuration constants.
-// Update PLAYIN_START_DATE each season to the official play-in tournament start date.
-// This date controls:
+// Season-level configuration constants. Update both dates each season.
+
+// When bracket submissions lock (play-in tournament start). Controls:
 //   - MVP and championship pick editing deadline
 //   - Bracket submission locking deadline
+export const PLAYIN_START_DATE = new Date('2026-04-14T20:00:00Z');
 
-export const PLAYIN_START_DATE = new Date('2026-04-14T20:00:00');
+// When bracket submissions open (after regular season ends). Update each season.
+export const PREDICTIONS_OPEN_DATE = new Date('2026-04-13T07:00:00Z');  // April 13 2026, 10:00 AM IDT


### PR DESCRIPTION
## Summary
- show the bracket submission open window in the bracket UI before picks are allowed
- disable bracket editing, random fill, and submit actions until the open time is reached
- show an explanatory tooltip on matchup cards before submissions open, including the exact opening hour
- fix mobile EditPicksDialog autocomplete overflow by letting the selector list escape the dialog container
- ignore the local-only bracket verification files in the client repo

## Testing
- bracket-focused Jest verification run locally
- EditPicksDialog focused Jest verification run locally

## Notes
- Companion server PR: https://github.com/darchock/NBA-Playoffs-Brackets-App-Server/pull/116