### PR TITLE
Fix standings UI: bold headers, trophy order, bot info, card borders, avatar groups

### DIFF
--- a/src/components/GlobalRankings.jsx
+++ b/src/components/GlobalRankings.jsx
@@ -14,6 +14,7 @@ import {
   useMediaQuery,
   useTheme
 } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { EmojiEvents as TrophyIcon } from '@mui/icons-material';
 import { PLAYER_AVATARS } from '../shared/GeneralConsts';
 
@@ -52,8 +53,8 @@ const GlobalRankings = ({ globalRankings }) => {
     if (rank === 1) {
       return (
         <Box display="flex" alignItems="center">
-          <TrophyIcon fontSize="small" sx={{ color: 'gold', mr: 0.5 }} />
           <Typography variant="body2" fontWeight="bold">1</Typography>
+          <TrophyIcon fontSize="small" sx={{ color: 'gold', ml: 0.5 }} />
         </Box>
       );
     }
@@ -87,18 +88,18 @@ const GlobalRankings = ({ globalRankings }) => {
   );
 
   const rowHighlight = (isMe) => ({
-    bgcolor: isMe ? `${theme.palette.primary.main}15` : 'inherit',
+    bgcolor: isMe ? alpha(theme.palette.primary.main, 0.13) : 'inherit',
   });
 
   return (
     <TableContainer component={Paper} elevation={2}>
       <Table size={isMobile ? 'small' : 'medium'}>
         <TableHead>
-          <TableRow>
-            <TableCell>Rank</TableCell>
-            <TableCell>Player</TableCell>
-            <TableCell>League</TableCell>
-            <TableCell align="right">Score</TableCell>
+          <TableRow sx={{ bgcolor: theme.palette.action.selected }}>
+            <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>Rank</TableCell>
+            <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>Player</TableCell>
+            <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>League</TableCell>
+            <TableCell align="right" sx={{ fontWeight: 700, color: 'text.primary' }}>Score</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/src/components/PlayerDetailDialog.jsx
+++ b/src/components/PlayerDetailDialog.jsx
@@ -7,6 +7,7 @@ import {
   Box,
   Typography,
   IconButton,
+  Alert,
   useMediaQuery,
   useTheme,
   Divider,
@@ -17,6 +18,11 @@ import {
 } from '@mui/icons-material';
 import PlayerStatsCard from './PlayerStatsCard';
 import UserServices from '../services/UserServices';
+
+const BOT_INFO = {
+  '100': 'Always bets on the favorite',
+  '101': 'Bets randomly on each matchup',
+};
 
 const PlayerDetailDialog = ({ player, leagueName, open, onClose }) => {
   const theme = useTheme();
@@ -72,6 +78,11 @@ const PlayerDetailDialog = ({ player, leagueName, open, onClose }) => {
       </DialogTitle>
       <Divider />
       <DialogContent sx={{ p: 3 }}>
+        {BOT_INFO[player?.playerAvatar] && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            {BOT_INFO[player.playerAvatar]}
+          </Alert>
+        )}
         {loading ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
             <CircularProgress />

--- a/src/components/PlayerDetailDialog.jsx
+++ b/src/components/PlayerDetailDialog.jsx
@@ -20,8 +20,8 @@ import PlayerStatsCard from './PlayerStatsCard';
 import UserServices from '../services/UserServices';
 
 const BOT_INFO = {
-  '100': 'Always bets on the favorite',
-  '101': 'Bets randomly on each matchup',
+  '100': 'Always bets on the home team in each matchup. Championship Team and Finals MVP are favorite.',
+  '101': 'Bets randomly on each matchup. Championship Team and Finals MVP are random as well',
 };
 
 const PlayerDetailDialog = ({ player, leagueName, open, onClose }) => {

--- a/src/components/PlayerStatsCard.js
+++ b/src/components/PlayerStatsCard.js
@@ -90,7 +90,9 @@ const PlayerStatsCard = ({
       sx={{
         p: isMobile ? 2 : 3,
         borderRadius: 2,
-        bgcolor: theme.palette.background.paper
+        bgcolor: theme.palette.background.paper,
+        border: '1px solid',
+        borderColor: 'divider'
       }}
     >
       <Box

--- a/src/components/StandingsTable.jsx
+++ b/src/components/StandingsTable.jsx
@@ -153,8 +153,8 @@ const RankCell = ({ rank }) => {
   if (rank <= 3) {
     return (
       <Box display="flex" alignItems="center">
-        <TrophyIcon fontSize="small" sx={{ color: MEDAL_COLORS[rank], mr: 0.5 }} />
         <Typography variant="body2" fontWeight="bold">{rank}</Typography>
+        <TrophyIcon fontSize="small" sx={{ color: MEDAL_COLORS[rank], ml: 0.5 }} />
       </Box>
     );
   }
@@ -246,7 +246,7 @@ const StandingsTable = ({ players, currentPlayerId, onPlayerSelect }) => {
   // Current-player row: background tint + left-edge accent via inset box-shadow
   // (border-left on <tr> is unreliable in the CSS table model)
   const buildRowSx = (isCurrentPlayer) => ({
-    bgcolor: isCurrentPlayer ? alpha(theme.palette.primary.main, 0.08) : 'inherit',
+    bgcolor: isCurrentPlayer ? alpha(theme.palette.primary.main, 0.13) : 'inherit',
     ...(isCurrentPlayer && {
       boxShadow: `inset 3px 0 0 ${theme.palette.primary.main}`,
     }),
@@ -269,30 +269,30 @@ const StandingsTable = ({ players, currentPlayerId, onPlayerSelect }) => {
     <TableContainer component={Paper} elevation={2}>
       <Table size={isMobile ? 'small' : 'medium'}>
         <TableHead>
-          <TableRow>
+          <TableRow sx={{ bgcolor: theme.palette.action.selected }}>
             {isMobile ? (
               <>
-                <TableCell>Rank</TableCell>
-                <TableCell>Player</TableCell>
-                <TableCell align="right">Total</TableCell>
+                <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>Rank</TableCell>
+                <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>Player</TableCell>
+                <TableCell align="right" sx={{ fontWeight: 700, color: 'text.primary' }}>Total</TableCell>
               </>
             ) : (
               <>
-                <TableCell>Rank</TableCell>
-                <TableCell>Player</TableCell>
-                <TableCell>Champion</TableCell>
-                <TableCell>Finals MVP</TableCell>
-                <TableCell align="right">
+                <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>Rank</TableCell>
+                <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>Player</TableCell>
+                <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>Champion</TableCell>
+                <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>Finals MVP</TableCell>
+                <TableCell align="right" sx={{ fontWeight: 700, color: 'text.primary' }}>
                   <TableSortLabel {...sortLabelProps('predictions')}>
                     Live Picks
                   </TableSortLabel>
                 </TableCell>
-                <TableCell align="right">
+                <TableCell align="right" sx={{ fontWeight: 700, color: 'text.primary' }}>
                   <TableSortLabel {...sortLabelProps('bracket')}>
                     Bracket
                   </TableSortLabel>
                 </TableCell>
-                <TableCell align="right">
+                <TableCell align="right" sx={{ fontWeight: 700, color: 'text.primary' }}>
                   <TableSortLabel {...sortLabelProps('total')}>
                     Total
                   </TableSortLabel>

--- a/src/shared/GeneralConsts.js
+++ b/src/shared/GeneralConsts.js
@@ -24,7 +24,7 @@ export const PLAYER_AVATARS = [
     { id: "20",  src: '/resources/player-avatars/Brady.png',             alt: 'Brady' },
     { id: "21",  src: '/resources/player-avatars/Federer.png',           alt: 'Federer' },
     { id: "22",  src: '/resources/player-avatars/Phelps.png',            alt: 'Phelps' },
-    { id: "23",  src: '/resources/player-avatars/fuck them kids.png',    alt: 'F.T.K.' },
+    { id: "23",  src: '/resources/player-avatars/fuck them kids.png',    alt: 'Fuck Them Kids' },
     { id: "24",  src: '/resources/player-avatars/Biles.png',             alt: 'Biles' },
     { id: "25",  src: '/resources/player-avatars/Hamilton.png',          alt: 'Hamilton' },
     { id: "26",  src: '/resources/player-avatars/Novak.png',             alt: 'Novak' },
@@ -47,8 +47,8 @@ export const PLAYER_AVATARS = [
 // Order within avatarIds controls display order inside the group.
 // To add a new group: add an entry here with a unique id, label, and avatarIds.
 export const PLAYER_AVATAR_GROUPS = [
-    { id: 'goats',       label: 'GOATs',         avatarIds: ['8', '10', '11', '15', '17', '19', '20', '21', '22', '24', '25', '26', '27', '28', '30', '31', '33', '35', '36'] },
-    { id: 'ballers',     label: 'Ballers',      avatarIds: ['2', '4', '12', '13', '14', '7', '6', '1', '9', '34'] },
+    { id: 'goats',       label: 'GOATs',         avatarIds: ['36', '8', '10', '11', '15', '19', '20', '21', '22', '24', '25', '28'] },
+    { id: 'ballers',     label: 'Ballers',      avatarIds: ['2', '4', '12', '13', '14', '17', '7', '6', '1', '9', '33', '35', '34'] },
     { id: 'politicians', label: 'World Leaders', avatarIds: ['3', '5'] },
-    { id: 'others',      label: 'Be Different',        avatarIds: ['16', '18', '23', '29', '32'] },
+    { id: 'others',      label: 'Be Different',        avatarIds: ['16', '18', '23', '29', '30', '31', '32', '26', '27'] },
 ];


### PR DESCRIPTION
## Summary
- **StandingsTable & GlobalRankings**: bold header cells + subtle primary-tinted background to make headers more noticeable; differentiated from (You) row which uses a stronger primary tint
- **StandingsTable & GlobalRankings**: trophy icon moved to right of rank number (\"1 🏆\" not \"🏆 1\")
- **PlayerStatsCard**: added border to Paper so the card is visible when rendered with elevation=0 (e.g. in PlayerDetailDialog)
- **PlayerDetailDialog**: shows a small info Alert for Lamb/Monkey bots based on avatar ID (\"100\"/\"101\") — environment-agnostic, no name matching
- **GeneralConsts**: reorganized PLAYER_AVATAR_GROUPS — Prophet moved to top of GOATs, avatars reshuffled across groups

## Paired PR
Server: darchock/NBA-Playoffs-Brackets-App-Server#118