### PR TITLE
Add landing page info section — how it works, scoring, scrollable below hero

### DIFF
--- a/src/components/LandingInfoSection.jsx
+++ b/src/components/LandingInfoSection.jsx
@@ -9,28 +9,32 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import {
-  SportsBasketball,
   EmojiEvents,
   Groups,
   Google,
   Whatshot,
   Star,
+  Lock,
 } from '@mui/icons-material';
+import { TbCrystalBall } from 'react-icons/tb';
 
 // ── How It Works ─────────────────────────────────────────────────────────────
+// Step 01 = Bonus Picks first (locked before playoffs begin — sets context)
+// Step 02 = Bracket / series predictions
+// Step 03 = Compete in league
 
 const STEPS = [
   {
     number: '01',
-    Icon: SportsBasketball,
-    title: 'Predict Every Series',
-    body: 'Before each matchup tips off, pick the winner and exact series score — from the Play-In all the way to the Finals.',
-  },
-  {
-    number: '02',
     Icon: EmojiEvents,
     title: 'Lock In Bonus Picks',
     body: 'Before the playoffs begin, choose your Championship winner and Finals MVP. Get them right for a big bonus.',
+  },
+  {
+    number: '02',
+    Icon: Whatshot,
+    title: 'Predict Every Series',
+    body: 'Fill and Lock your full bracket before the Play-In games begin. Live pick every series winner and exact score, from the Play-In through the Finals.',
   },
   {
     number: '03',
@@ -154,7 +158,7 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
           </Box>
         </Box>
 
-        {/* ── Scoring at a Glance ── */}
+        {/* ── Scoring ── */}
         <Box sx={{ mb: onSignIn ? { xs: 8, md: 10 } : 0 }}>
           <Typography
             variant="overline"
@@ -163,6 +167,7 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
               textAlign: 'center',
               color: 'secondary.main',
               letterSpacing: 4,
+              textTransform: 'none',   // override MUI overline auto-uppercase
               mb: 1,
             }}
           >
@@ -171,9 +176,23 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
           <Typography
             variant={isMobile ? 'h5' : 'h4'}
             fontWeight="bold"
-            sx={{ textAlign: 'center', color: 'white', mb: { xs: 4, md: 6 } }}
+            sx={{ textAlign: 'center', color: 'white', mb: 1.5 }}
           >
             Points escalate every round
+          </Typography>
+          {/* Bracket vs live picks clarification */}
+          <Typography
+            variant="body2"
+            sx={{
+              textAlign: 'center',
+              color: 'rgba(255,255,255,0.55)',
+              mb: { xs: 4, md: 5 },
+              maxWidth: 520,
+              mx: 'auto',
+              lineHeight: 1.7,
+            }}
+          >
+            As Bracket picks locks before the Play-In games they worth more than live series picks.
           </Typography>
 
           {/* Round escalation — horizontal scroll on mobile */}
@@ -191,7 +210,7 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
             }}
           >
             {ROUNDS.map(({ label, sublabel }, index) => {
-              // Visually grow each round chip: opacity + border intensity + size
+              // Visually grow each round chip: opacity + border intensity
               const intensity = 0.35 + (index / (ROUNDS.length - 1)) * 0.65;
               const isLast = index === ROUNDS.length - 1;
               return (
@@ -203,7 +222,7 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
                     alignItems: 'center',
                     gap: 0.5,
                     bgcolor: isLast
-                      ? 'rgba(211,47,47,0.18)'   // Finals gets a red tint
+                      ? 'rgba(211,47,47,0.18)'
                       : `rgba(255,255,255,${0.04 + index * 0.015})`,
                     border: '1px solid',
                     borderColor: isLast
@@ -247,53 +266,99 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
             })}
           </Box>
 
-          {/* Bonus callouts */}
+          {/* Bonus callouts — 3 cards */}
           <Box
             sx={{
               display: 'flex',
               flexDirection: { xs: 'column', sm: 'row' },
+              flexWrap: { sm: 'wrap' },
               gap: 2,
               justifyContent: 'center',
             }}
           >
-            {[
-              {
-                Icon: Whatshot,
-                label: 'Bullseye Bonus',
-                desc: 'Nail the exact series score for extra points',
-              },
-              {
-                Icon: EmojiEvents,
-                label: 'Bonus Picks',
-                desc: 'Championship winner + Finals MVP = bonus rounds',
-              },
-            ].map(({ Icon, label, desc }) => (
-              <Box
-                key={label}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'flex-start',
-                  gap: 1.5,
-                  bgcolor: 'rgba(255,255,255,0.04)',
-                  border: '1px solid rgba(255,255,255,0.09)',
-                  borderRadius: 2,
-                  px: 2.5,
-                  py: 2,
-                  maxWidth: { sm: 320 },
-                  width: '100%',
-                }}
-              >
-                <Icon sx={{ color: 'secondary.main', fontSize: 22, mt: 0.25, flexShrink: 0 }} />
-                <Box>
-                  <Typography variant="body2" fontWeight="bold" sx={{ color: 'white', lineHeight: 1.3 }}>
-                    {label}
-                  </Typography>
-                  <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.55)', lineHeight: 1.5 }}>
-                    {desc}
-                  </Typography>
-                </Box>
+            {/* Bullseye Bonus — react-icons TbCrystalBall */}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 1.5,
+                bgcolor: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.09)',
+                borderRadius: 2,
+                px: 2.5,
+                py: 2,
+                maxWidth: { sm: 300 },
+                width: '100%',
+              }}
+            >
+              {/*
+                TbCrystalBall is from react-icons and doesn't accept the MUI sx prop.
+                Wrapping in a Box with color set lets us use theme color via currentColor.
+              */}
+              <Box sx={{ color: 'secondary.main', display: 'flex', mt: 0.25, flexShrink: 0 }}>
+                <TbCrystalBall size={22} color="currentColor" />
               </Box>
-            ))}
+              <Box>
+                <Typography variant="body2" fontWeight="bold" sx={{ color: 'white', lineHeight: 1.3 }}>
+                  Bullseye Bonus
+                </Typography>
+                <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.55)', lineHeight: 1.5 }}>
+                  Nail the exact series score for extra points
+                </Typography>
+              </Box>
+            </Box>
+
+            {/* Bonus Picks */}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 1.5,
+                bgcolor: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.09)',
+                borderRadius: 2,
+                px: 2.5,
+                py: 2,
+                maxWidth: { sm: 300 },
+                width: '100%',
+              }}
+            >
+              <EmojiEvents sx={{ color: 'secondary.main', fontSize: 22, mt: 0.25, flexShrink: 0 }} />
+              <Box>
+                <Typography variant="body2" fontWeight="bold" sx={{ color: 'white', lineHeight: 1.3 }}>
+                  Bonus Picks
+                </Typography>
+                <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.55)', lineHeight: 1.5 }}>
+                  Championship winner + Finals MVP = bonus rounds
+                </Typography>
+              </Box>
+            </Box>
+
+            {/* Bracket picks pay more */}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 1.5,
+                bgcolor: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.09)',
+                borderRadius: 2,
+                px: 2.5,
+                py: 2,
+                maxWidth: { sm: 300 },
+                width: '100%',
+              }}
+            >
+              <Lock sx={{ color: 'secondary.main', fontSize: 22, mt: 0.25, flexShrink: 0 }} />
+              <Box>
+                <Typography variant="body2" fontWeight="bold" sx={{ color: 'white', lineHeight: 1.3 }}>
+                  Early Lock Multiplier
+                </Typography>
+                <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.55)', lineHeight: 1.5 }}>
+                  Bracket picks beat live picks — commit before playoffs for bigger rewards
+                </Typography>
+              </Box>
+            </Box>
           </Box>
         </Box>
 
@@ -305,7 +370,7 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
               flexDirection: 'column',
               alignItems: 'center',
               gap: 2,
-              pt: { xs: 2, md: 3 },
+              pt: { xs: 4, md: 5 },
               borderTop: '1px solid rgba(255,255,255,0.08)',
             }}
           >

--- a/src/components/LandingInfoSection.jsx
+++ b/src/components/LandingInfoSection.jsx
@@ -99,6 +99,7 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
               textAlign: 'center',
               color: 'secondary.main',
               letterSpacing: 4,
+              textTransform: 'none',
               mb: 1,
             }}
           >
@@ -139,7 +140,7 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
               <CalendarToday sx={{ color: 'rgba(255,255,255,0.55)', fontSize: 16 }} />
               <Box>
                 <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.45)', display: 'block', lineHeight: 1.2 }}>
-                  Bracket opens
+                  Bracket opens after regular season ends
                 </Typography>
                 <Typography variant="caption" fontWeight="bold" sx={{ color: 'white', display: 'block', lineHeight: 1.2 }}>
                   {fmt(PREDICTIONS_OPEN_DATE)}

--- a/src/components/LandingInfoSection.jsx
+++ b/src/components/LandingInfoSection.jsx
@@ -15,8 +15,14 @@ import {
   Whatshot,
   Star,
   Lock,
+  CalendarToday,
+  LockClock,
 } from '@mui/icons-material';
 import { TbCrystalBall } from 'react-icons/tb';
+import { PREDICTIONS_OPEN_DATE, PLAYIN_START_DATE } from '../shared/SeasonConfig';
+
+// Format a Date as "Apr 13" in the user's local locale.
+const fmt = (date) => date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 
 // ── How It Works ─────────────────────────────────────────────────────────────
 // Step 01 = Bonus Picks first (locked before playoffs begin — sets context)
@@ -40,7 +46,7 @@ const STEPS = [
     number: '03',
     Icon: Groups,
     title: 'Compete in Your League',
-    body: 'Join a private league with your crew, track live standings, and settle the GOAT debate once and for all.',
+    body: 'Join multiple private leagues with different crews — each league gets its own set of predictions. Track live standings per league and settle the GOAT debate once and for all.',
   },
 ];
 
@@ -101,10 +107,88 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
           <Typography
             variant={isMobile ? 'h5' : 'h4'}
             fontWeight="bold"
-            sx={{ textAlign: 'center', color: 'white', mb: { xs: 5, md: 7 } }}
+            sx={{ textAlign: 'center', color: 'white', mb: { xs: 3, md: 4 } }}
           >
             Three steps. One champion.
           </Typography>
+
+          {/* ── Key Dates strip ── */}
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: { xs: 'column', sm: 'row' },
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: { xs: 1, sm: 0 },
+              mb: { xs: 5, md: 7 },
+            }}
+          >
+            {/* Opens chip */}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                bgcolor: 'rgba(255,255,255,0.06)',
+                border: '1px solid rgba(255,255,255,0.14)',
+                borderRadius: { xs: 2, sm: '8px 0 0 8px' },
+                px: 2.5,
+                py: 1.25,
+              }}
+            >
+              <CalendarToday sx={{ color: 'rgba(255,255,255,0.55)', fontSize: 16 }} />
+              <Box>
+                <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.45)', display: 'block', lineHeight: 1.2 }}>
+                  Bracket opens
+                </Typography>
+                <Typography variant="caption" fontWeight="bold" sx={{ color: 'white', display: 'block', lineHeight: 1.2 }}>
+                  {fmt(PREDICTIONS_OPEN_DATE)}
+                </Typography>
+              </Box>
+            </Box>
+
+            {/* Arrow divider — desktop only */}
+            <Box
+              sx={{
+                display: { xs: 'none', sm: 'flex' },
+                alignItems: 'center',
+                bgcolor: 'rgba(255,255,255,0.06)',
+                borderTop: '1px solid rgba(255,255,255,0.14)',
+                borderBottom: '1px solid rgba(255,255,255,0.14)',
+                py: 1.25,
+                px: 1,
+                color: 'rgba(255,255,255,0.3)',
+                fontSize: 12,
+              }}
+            >
+              →
+            </Box>
+
+            {/* Locks chip */}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                bgcolor: 'rgba(211,47,47,0.14)',
+                border: '1px solid',
+                borderColor: 'secondary.main',
+                borderRadius: { xs: 2, sm: '0 8px 8px 0' },
+                px: 2.5,
+                py: 1.25,
+              }}
+            >
+              <LockClock sx={{ color: 'secondary.main', fontSize: 16 }} />
+              <Box>
+                <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.55)', display: 'block', lineHeight: 1.2 }}>
+                  Locks at Play-In tip-off
+                </Typography>
+                <Typography variant="caption" fontWeight="bold" sx={{ color: 'secondary.main', display: 'block', lineHeight: 1.2 }}>
+                  {fmt(PLAYIN_START_DATE)}
+                </Typography>
+              </Box>
+            </Box>
+          </Box>
 
           <Box
             sx={{

--- a/src/components/LandingInfoSection.jsx
+++ b/src/components/LandingInfoSection.jsx
@@ -1,0 +1,340 @@
+import React from 'react';
+import {
+  Box,
+  Container,
+  Typography,
+  Button,
+  CircularProgress,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material';
+import {
+  SportsBasketball,
+  EmojiEvents,
+  Groups,
+  Google,
+  Whatshot,
+  Star,
+} from '@mui/icons-material';
+
+// ── How It Works ─────────────────────────────────────────────────────────────
+
+const STEPS = [
+  {
+    number: '01',
+    Icon: SportsBasketball,
+    title: 'Predict Every Series',
+    body: 'Before each matchup tips off, pick the winner and exact series score — from the Play-In all the way to the Finals.',
+  },
+  {
+    number: '02',
+    Icon: EmojiEvents,
+    title: 'Lock In Bonus Picks',
+    body: 'Before the playoffs begin, choose your Championship winner and Finals MVP. Get them right for a big bonus.',
+  },
+  {
+    number: '03',
+    Icon: Groups,
+    title: 'Compete in Your League',
+    body: 'Join a private league with your crew, track live standings, and settle the GOAT debate once and for all.',
+  },
+];
+
+// ── Scoring rounds ────────────────────────────────────────────────────────────
+
+const ROUNDS = [
+  { label: 'Play-In',      sublabel: 'Pick the qualifier' },
+  { label: 'Round 1',      sublabel: '8 series' },
+  { label: 'Semis',        sublabel: '4 series' },
+  { label: 'Conf. Finals', sublabel: '2 series' },
+  { label: 'Finals',       sublabel: '1 series' },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Shared informational section used by both LandingPage and InviteLandingPage.
+ *
+ * Props:
+ *   onSignIn  – callback for the bottom CTA button. Omit to hide the CTA entirely
+ *               (e.g. when the user is already authenticated on the invite page).
+ *   loading   – shows a spinner in place of the Google icon while signing in.
+ */
+const LandingInfoSection = ({ onSignIn, loading = false }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  return (
+    <Box
+      component="section"
+      sx={{
+        position: 'relative',
+        zIndex: 1,
+        // Semi-transparent dark layer so the fixed bg image shows through subtly.
+        bgcolor: 'rgba(0, 0, 0, 0.78)',
+        backdropFilter: 'blur(6px)',
+        WebkitBackdropFilter: 'blur(6px)',
+        borderTop: '1px solid rgba(255,255,255,0.08)',
+        py: { xs: 7, md: 10 },
+      }}
+    >
+      <Container maxWidth="lg">
+
+        {/* ── How It Works ── */}
+        <Box sx={{ mb: { xs: 8, md: 10 } }}>
+          <Typography
+            variant="overline"
+            sx={{
+              display: 'block',
+              textAlign: 'center',
+              color: 'secondary.main',
+              letterSpacing: 4,
+              mb: 1,
+            }}
+          >
+            How It Works
+          </Typography>
+          <Typography
+            variant={isMobile ? 'h5' : 'h4'}
+            fontWeight="bold"
+            sx={{ textAlign: 'center', color: 'white', mb: { xs: 5, md: 7 } }}
+          >
+            Three steps. One champion.
+          </Typography>
+
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', md: 'repeat(3, 1fr)' },
+              gap: { xs: 3, md: 4 },
+            }}
+          >
+            {STEPS.map(({ number, Icon, title, body }) => (
+              <Box
+                key={number}
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 2,
+                  bgcolor: 'rgba(255,255,255,0.05)',
+                  border: '1px solid rgba(255,255,255,0.10)',
+                  borderRadius: 3,
+                  p: { xs: 3, md: 4 },
+                  // Subtle left accent on desktop
+                  borderLeft: { md: '3px solid' },
+                  borderLeftColor: { md: 'secondary.main' },
+                }}
+              >
+                {/* Step number + icon */}
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                  <Typography
+                    variant="h6"
+                    sx={{
+                      fontWeight: 900,
+                      color: 'secondary.main',
+                      lineHeight: 1,
+                      fontVariantNumeric: 'tabular-nums',
+                      minWidth: 32,
+                    }}
+                  >
+                    {number}
+                  </Typography>
+                  <Icon sx={{ color: 'rgba(255,255,255,0.55)', fontSize: 24 }} />
+                </Box>
+
+                <Typography variant="h6" fontWeight="bold" sx={{ color: 'white', lineHeight: 1.3 }}>
+                  {title}
+                </Typography>
+
+                <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.62)', lineHeight: 1.7 }}>
+                  {body}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+
+        {/* ── Scoring at a Glance ── */}
+        <Box sx={{ mb: onSignIn ? { xs: 8, md: 10 } : 0 }}>
+          <Typography
+            variant="overline"
+            sx={{
+              display: 'block',
+              textAlign: 'center',
+              color: 'secondary.main',
+              letterSpacing: 4,
+              mb: 1,
+            }}
+          >
+            Scoring
+          </Typography>
+          <Typography
+            variant={isMobile ? 'h5' : 'h4'}
+            fontWeight="bold"
+            sx={{ textAlign: 'center', color: 'white', mb: { xs: 4, md: 6 } }}
+          >
+            Points escalate every round
+          </Typography>
+
+          {/* Round escalation — horizontal scroll on mobile */}
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: { xs: 'flex-start', md: 'center' },
+              gap: { xs: 1.5, md: 2 },
+              overflowX: { xs: 'auto', md: 'visible' },
+              pb: { xs: 1, md: 0 },
+              '&::-webkit-scrollbar': { display: 'none' },
+              scrollbarWidth: 'none',
+              mb: { xs: 4, md: 5 },
+            }}
+          >
+            {ROUNDS.map(({ label, sublabel }, index) => {
+              // Visually grow each round chip: opacity + border intensity + size
+              const intensity = 0.35 + (index / (ROUNDS.length - 1)) * 0.65;
+              const isLast = index === ROUNDS.length - 1;
+              return (
+                <Box
+                  key={label}
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 0.5,
+                    bgcolor: isLast
+                      ? 'rgba(211,47,47,0.18)'   // Finals gets a red tint
+                      : `rgba(255,255,255,${0.04 + index * 0.015})`,
+                    border: '1px solid',
+                    borderColor: isLast
+                      ? 'secondary.main'
+                      : `rgba(255,255,255,${intensity * 0.35})`,
+                    borderRadius: 2,
+                    px: { xs: 2, md: 2.5 },
+                    py: { xs: 1.25, md: 1.5 },
+                    minWidth: { xs: 80, md: 100 },
+                    flexShrink: 0,
+                    transition: 'all 0.2s',
+                  }}
+                >
+                  {isLast && (
+                    <Star sx={{ color: 'secondary.main', fontSize: 14, mb: 0.25 }} />
+                  )}
+                  <Typography
+                    variant="caption"
+                    fontWeight="bold"
+                    sx={{
+                      color: isLast ? 'secondary.main' : `rgba(255,255,255,${intensity})`,
+                      textAlign: 'center',
+                      lineHeight: 1.2,
+                    }}
+                  >
+                    {label}
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: `rgba(255,255,255,${intensity * 0.6})`,
+                      textAlign: 'center',
+                      fontSize: '0.65rem',
+                      lineHeight: 1.2,
+                    }}
+                  >
+                    {sublabel}
+                  </Typography>
+                </Box>
+              );
+            })}
+          </Box>
+
+          {/* Bonus callouts */}
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: { xs: 'column', sm: 'row' },
+              gap: 2,
+              justifyContent: 'center',
+            }}
+          >
+            {[
+              {
+                Icon: Whatshot,
+                label: 'Bullseye Bonus',
+                desc: 'Nail the exact series score for extra points',
+              },
+              {
+                Icon: EmojiEvents,
+                label: 'Bonus Picks',
+                desc: 'Championship winner + Finals MVP = bonus rounds',
+              },
+            ].map(({ Icon, label, desc }) => (
+              <Box
+                key={label}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 1.5,
+                  bgcolor: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(255,255,255,0.09)',
+                  borderRadius: 2,
+                  px: 2.5,
+                  py: 2,
+                  maxWidth: { sm: 320 },
+                  width: '100%',
+                }}
+              >
+                <Icon sx={{ color: 'secondary.main', fontSize: 22, mt: 0.25, flexShrink: 0 }} />
+                <Box>
+                  <Typography variant="body2" fontWeight="bold" sx={{ color: 'white', lineHeight: 1.3 }}>
+                    {label}
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.55)', lineHeight: 1.5 }}>
+                    {desc}
+                  </Typography>
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+
+        {/* ── Bottom CTA ── (only rendered when onSignIn is provided) */}
+        {onSignIn && (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 2,
+              pt: { xs: 2, md: 3 },
+              borderTop: '1px solid rgba(255,255,255,0.08)',
+            }}
+          >
+            <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.65)', textAlign: 'center' }}>
+              Ready to prove you're the GOAT?
+            </Typography>
+            <Button
+              variant="contained"
+              color="secondary"
+              size="large"
+              startIcon={loading ? <CircularProgress size={20} color="inherit" /> : <Google />}
+              onClick={onSignIn}
+              disabled={loading}
+              sx={{
+                px: 5,
+                py: 1.75,
+                fontSize: '1.05rem',
+                fontWeight: 'bold',
+                boxShadow: '0 4px 20px rgba(0,0,0,0.45)',
+              }}
+            >
+              {loading ? 'Loading...' : 'Sign in with Google to Join'}
+            </Button>
+          </Box>
+        )}
+
+      </Container>
+    </Box>
+  );
+};
+
+export default LandingInfoSection;

--- a/src/components/LandingInfoSection.jsx
+++ b/src/components/LandingInfoSection.jsx
@@ -21,8 +21,9 @@ import {
 import { TbCrystalBall } from 'react-icons/tb';
 import { PREDICTIONS_OPEN_DATE, PLAYIN_START_DATE } from '../shared/SeasonConfig';
 
-// Format a Date as "Apr 13" in the user's local locale.
-const fmt = (date) => date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+// Format a Date as "Apr 13, 10:00 AM" in the user's local timezone.
+const fmt = (date) =>
+  date.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
 
 // ── How It Works ─────────────────────────────────────────────────────────────
 // Step 01 = Bonus Picks first (locked before playoffs begin — sets context)

--- a/src/components/LandingInfoSection.jsx
+++ b/src/components/LandingInfoSection.jsx
@@ -118,7 +118,8 @@ const LandingInfoSection = ({ onSignIn, loading = false }) => {
             sx={{
               display: 'flex',
               flexDirection: { xs: 'column', sm: 'row' },
-              alignItems: 'center',
+              // stretch → both chips fill the same width when stacked on mobile
+              alignItems: { xs: 'stretch', sm: 'center' },
               justifyContent: 'center',
               gap: { xs: 1, sm: 0 },
               mb: { xs: 5, md: 7 },

--- a/src/pages/InviteLandingPage.jsx
+++ b/src/pages/InviteLandingPage.jsx
@@ -55,8 +55,11 @@ const InviteLandingPage = () => {
     try {
       setSigningIn(true);
       await signInWithGoogle();
+      // Scroll to top so the invite card (hero) is visible after signing in,
+      // especially important when the user clicked the bottom CTA.
+      window.scrollTo({ top: 0, behavior: 'smooth' });
       if (window.notify) {
-        window.notify.success('Signed in successfully!');
+        window.notify.info("You're signed in — check out your invite above!");
       }
     } catch (err) {
       setError('Sign in failed. Please try again.');

--- a/src/pages/InviteLandingPage.jsx
+++ b/src/pages/InviteLandingPage.jsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/icons-material';
 
 import ThemeToggle from '../theme/ThemeToggle';
+import LandingInfoSection from '../components/LandingInfoSection';
 import LeagueServices from '../services/LeagueServices';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -79,211 +80,228 @@ const InviteLandingPage = () => {
         display: 'flex',
         flexDirection: 'column',
         minHeight: '100vh',
-        overflow: 'hidden',
       }}
     >
-      {/* Background image — same as LandingPage for brand consistency */}
+      {/*
+        Background image — fixed so it remains visible as the user scrolls
+        into the info section below the hero.
+      */}
       <Box
         component="img"
         src="/og-image-clean.png"
         alt=""
         aria-hidden="true"
         sx={{
-          position: 'absolute',
+          position: 'fixed',
           top: 0,
           left: 0,
           width: '100%',
           height: '100%',
           objectFit: 'cover',
-          /*
-            Mobile: goat centered (default position).
-            Desktop: shift left so the goat occupies the center-left of the
-            viewport and the card sits on the right without covering it.
-          */
           objectPosition: { xs: '78% center', md: '62% center' },
           zIndex: 0,
         }}
       />
 
-      {/* Overlay — uniform dark across mobile; right-side fade on desktop */}
+      {/* ── Hero — full viewport height ── */}
       <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          background: {
-            xs: 'rgba(0,0,0,0.52)',
-            md: 'linear-gradient(to right, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.55) 35%, rgba(0,0,0,0.20) 65%, rgba(0,0,0,0.05) 100%)',
-          },
-          zIndex: 1,
-        }}
-      />
-
-      {/* Transparent header */}
-      <AppBar
-        position="relative"
-        sx={{ background: 'transparent', boxShadow: 'none', zIndex: 2 }}
-      >
-        <Toolbar>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexGrow: 1 }}>
-            <Box
-              component="img"
-              src={NAV_LOGO_SRC}
-              alt="Playoff Prophet logo"
-              sx={{ width: 36, height: 36, borderRadius: '50%' }}
-            />
-            <Typography variant="h6" fontWeight="bold" sx={{ color: 'white' }}>
-              Playoff Prophet
-            </Typography>
-          </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <ThemeToggle />
-            {isAuthenticated && (
-              <>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  onClick={handleGoToDashboard}
-                  sx={{ color: 'white', borderColor: 'rgba(255,255,255,0.4)' }}
-                >
-                  Home
-                </Button>
-                <Button
-                  size="small"
-                  onClick={logout}
-                  sx={{ color: 'rgba(255,255,255,0.7)' }}
-                >
-                  Logout
-                </Button>
-              </>
-            )}
-          </Box>
-        </Toolbar>
-      </AppBar>
-
-      {/*
-        Content area — centered on mobile, right-aligned on desktop
-        so the goat (center-left of image) is fully visible alongside the card.
-      */}
-      <Box
+        component="section"
         sx={{
           position: 'relative',
-          zIndex: 2,
-          flexGrow: 1,
+          minHeight: '100vh',
           display: 'flex',
-          alignItems: 'center',
-          justifyContent: { xs: 'center', md: 'flex-start' },
-          // Mobile: push card to the lower half so the goat face is unobstructed above
-          alignItems: { xs: 'flex-end', md: 'center' },
-          pb: { xs: 5, md: 0 },
-          pt: { xs: 2, md: 4 },
-          pl: { md: 8 },
+          flexDirection: 'column',
+          zIndex: 1,
         }}
       >
-        <Box sx={{ width: { xs: '90%', sm: 340 } }}>
+        {/* Overlay — uniform dark across mobile; right-side fade on desktop */}
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            background: {
+              xs: 'rgba(0,0,0,0.52)',
+              md: 'linear-gradient(to right, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.55) 35%, rgba(0,0,0,0.20) 65%, rgba(0,0,0,0.05) 100%)',
+            },
+            zIndex: 1,
+          }}
+        />
 
-          {/* Loading state */}
-          {(authLoading || loading) && (
-            <Box sx={{ textAlign: 'center' }}>
-              <CircularProgress sx={{ color: 'white' }} />
-              <Typography sx={{ mt: 2, color: 'rgba(255,255,255,0.8)' }}>
-                Loading invite...
+        {/* Transparent header */}
+        <AppBar
+          position="relative"
+          sx={{ background: 'transparent', boxShadow: 'none', zIndex: 2 }}
+        >
+          <Toolbar>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexGrow: 1 }}>
+              <Box
+                component="img"
+                src={NAV_LOGO_SRC}
+                alt="Playoff Prophet logo"
+                sx={{ width: 36, height: 36, borderRadius: '50%' }}
+              />
+              <Typography variant="h6" fontWeight="bold" sx={{ color: 'white' }}>
+                Playoff Prophet
               </Typography>
             </Box>
-          )}
-
-          {/* Error state */}
-          {!authLoading && !loading && error && (
-            <Box>
-              <Alert severity="error" sx={{ mb: 2 }}>
-                {error}
-              </Alert>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <ThemeToggle />
               {isAuthenticated && (
-                <Button variant="contained" onClick={handleGoToDashboard}>
-                  Go to Dashboard
-                </Button>
-              )}
-            </Box>
-          )}
-
-          {/* Glass invite card */}
-          {!authLoading && !loading && !error && preview && (
-            <Box
-              sx={{
-                backdropFilter: 'blur(16px)',
-                WebkitBackdropFilter: 'blur(16px)',
-                bgcolor: 'rgba(255,255,255,0.10)',
-                border: '1px solid rgba(255,255,255,0.20)',
-                borderRadius: 3,
-                p: 3,
-                textAlign: 'center',
-              }}
-            >
-              <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.7)', mb: 0.5 }}>
-                You've been invited to join
-              </Typography>
-              <Typography
-                variant="h5"
-                gutterBottom
-                sx={{ fontWeight: 'bold', color: 'secondary.main', mb: 1 }}
-              >
-                {preview.leagueName}
-              </Typography>
-
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2.5 }}>
-                <GroupsIcon sx={{ mr: 1, color: 'rgba(255,255,255,0.55)', fontSize: 18 }} />
-                <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.65)' }}>
-                  {preview.playerCount} {preview.playerCount === 1 ? 'player' : 'players'}
-                </Typography>
-              </Box>
-
-              {/* Not authenticated — prompt sign in */}
-              {!isAuthenticated && (
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  size="large"
-                  startIcon={signingIn ? <CircularProgress size={20} color="inherit" /> : <LoginIcon />}
-                  onClick={handleSignIn}
-                  disabled={signingIn}
-                  fullWidth
-                >
-                  {signingIn ? 'Signing in...' : 'Sign in with Google to Join'}
-                </Button>
-              )}
-
-              {/* Authenticated but already a member */}
-              {isAuthenticated && isAlreadyMember && (
                 <>
-                  <Alert severity="info" sx={{ mb: 2 }}>
-                    You're already a member of this league.
-                  </Alert>
-                  <Button variant="contained" onClick={handleGoToDashboard} fullWidth>
-                    Go to Dashboard
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={handleGoToDashboard}
+                    sx={{ color: 'white', borderColor: 'rgba(255,255,255,0.4)' }}
+                  >
+                    Home
+                  </Button>
+                  <Button
+                    size="small"
+                    onClick={logout}
+                    sx={{ color: 'rgba(255,255,255,0.7)' }}
+                  >
+                    Logout
                   </Button>
                 </>
               )}
-
-              {/* Authenticated and not a member — ready to join */}
-              {isAuthenticated && !isAlreadyMember && (
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  size="large"
-                  onClick={handleJoin}
-                  fullWidth
-                >
-                  Join League
-                </Button>
-              )}
             </Box>
-          )}
+          </Toolbar>
+        </AppBar>
+
+        {/*
+          Content area — centered on mobile, left-aligned on desktop
+          so the goat (center-left of image) is fully visible alongside the card.
+        */}
+        <Box
+          sx={{
+            position: 'relative',
+            zIndex: 2,
+            flexGrow: 1,
+            display: 'flex',
+            alignItems: { xs: 'flex-end', md: 'center' },
+            justifyContent: { xs: 'center', md: 'flex-start' },
+            pb: { xs: 5, md: 0 },
+            pt: { xs: 2, md: 4 },
+            pl: { md: 8 },
+          }}
+        >
+          <Box sx={{ width: { xs: '90%', sm: 340 } }}>
+
+            {/* Loading state */}
+            {(authLoading || loading) && (
+              <Box sx={{ textAlign: 'center' }}>
+                <CircularProgress sx={{ color: 'white' }} />
+                <Typography sx={{ mt: 2, color: 'rgba(255,255,255,0.8)' }}>
+                  Loading invite...
+                </Typography>
+              </Box>
+            )}
+
+            {/* Error state */}
+            {!authLoading && !loading && error && (
+              <Box>
+                <Alert severity="error" sx={{ mb: 2 }}>
+                  {error}
+                </Alert>
+                {isAuthenticated && (
+                  <Button variant="contained" onClick={handleGoToDashboard}>
+                    Go to Dashboard
+                  </Button>
+                )}
+              </Box>
+            )}
+
+            {/* Glass invite card */}
+            {!authLoading && !loading && !error && preview && (
+              <Box
+                sx={{
+                  backdropFilter: 'blur(16px)',
+                  WebkitBackdropFilter: 'blur(16px)',
+                  bgcolor: 'rgba(255,255,255,0.10)',
+                  border: '1px solid rgba(255,255,255,0.20)',
+                  borderRadius: 3,
+                  p: 3,
+                  textAlign: 'center',
+                }}
+              >
+                <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.7)', mb: 0.5 }}>
+                  You've been invited to join
+                </Typography>
+                <Typography
+                  variant="h5"
+                  gutterBottom
+                  sx={{ fontWeight: 'bold', color: 'secondary.main', mb: 1 }}
+                >
+                  {preview.leagueName}
+                </Typography>
+
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2.5 }}>
+                  <GroupsIcon sx={{ mr: 1, color: 'rgba(255,255,255,0.55)', fontSize: 18 }} />
+                  <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.65)' }}>
+                    {preview.playerCount} {preview.playerCount === 1 ? 'player' : 'players'}
+                  </Typography>
+                </Box>
+
+                {/* Not authenticated — prompt sign in */}
+                {!isAuthenticated && (
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    size="large"
+                    startIcon={signingIn ? <CircularProgress size={20} color="inherit" /> : <LoginIcon />}
+                    onClick={handleSignIn}
+                    disabled={signingIn}
+                    fullWidth
+                  >
+                    {signingIn ? 'Signing in...' : 'Sign in with Google to Join'}
+                  </Button>
+                )}
+
+                {/* Authenticated but already a member */}
+                {isAuthenticated && isAlreadyMember && (
+                  <>
+                    <Alert severity="info" sx={{ mb: 2 }}>
+                      You're already a member of this league.
+                    </Alert>
+                    <Button variant="contained" onClick={handleGoToDashboard} fullWidth>
+                      Go to Dashboard
+                    </Button>
+                  </>
+                )}
+
+                {/* Authenticated and not a member — ready to join */}
+                {isAuthenticated && !isAlreadyMember && (
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    size="large"
+                    onClick={handleJoin}
+                    fullWidth
+                  >
+                    Join League
+                  </Button>
+                )}
+              </Box>
+            )}
+          </Box>
         </Box>
       </Box>
+
+      {/* ── Informational section — scrolls below the hero ── */}
+      {/*
+        Only show the bottom CTA when unauthenticated — authenticated users
+        already have the Join / Dashboard buttons in the invite card above.
+      */}
+      <LandingInfoSection
+        onSignIn={!isAuthenticated ? handleSignIn : undefined}
+        loading={signingIn}
+      />
 
       {/* ── Footer — same as LandingPage ── */}
       <Box
         component="footer"
-        sx={{ py: 2.5, bgcolor: '#111111', color: 'white', position: 'relative', zIndex: 2 }}
+        sx={{ py: 2.5, bgcolor: '#111111', color: 'white', position: 'relative', zIndex: 1 }}
       >
         <Container maxWidth="lg">
           <Box sx={{ textAlign: 'center' }}>

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import ThemeToggle from '../theme/ThemeToggle';
+import LandingInfoSection from '../components/LandingInfoSection';
 import {
   Box,
   AppBar,
@@ -98,7 +99,28 @@ const LandingPage = () => {
   };
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh', position: 'relative' }}>
+
+      {/*
+        Background image — fixed so it remains visible as the user scrolls
+        into the info section below the hero.
+      */}
+      <Box
+        component="img"
+        src="/og-image-clean.png"
+        alt=""
+        aria-hidden="true"
+        sx={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
+          objectPosition: { xs: '78% center', md: '62% center' },
+          zIndex: 0,
+        }}
+      />
 
       {/* ── Hero — full viewport height ── */}
       <Box
@@ -108,30 +130,9 @@ const LandingPage = () => {
           minHeight: '100vh',
           display: 'flex',
           flexDirection: 'column',
-          overflow: 'hidden',
+          zIndex: 1,
         }}
       >
-        {/*
-          Background image.
-          - Desktop: goat sits right-of-center, text overlays the left half.
-          - Mobile: shift right so the goat is visible; CTA is pinned to the bottom.
-        */}
-        <Box
-          component="img"
-          src="/og-image-clean.png"
-          alt=""
-          aria-hidden="true"
-          sx={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-            objectFit: 'cover',
-            objectPosition: { xs: '78% center', md: '62% center' },
-            zIndex: 0,
-          }}
-        />
 
         {/*
           Gradient overlay.
@@ -275,7 +276,7 @@ const LandingPage = () => {
                   boxShadow: '0 4px 20px rgba(0,0,0,0.45)',
                 }}
               >
-                {loading ? 'Loading...' : 'Sign in with Google'}
+                {loading ? 'Loading...' : 'Sign in with Google to Join'}
               </Button>
             </Box>
           </Container>
@@ -387,10 +388,13 @@ const LandingPage = () => {
         </Box>
       </Box>
 
+      {/* ── Informational section — scrolls below the hero ── */}
+      <LandingInfoSection onSignIn={handleSignIn} loading={loading} />
+
       {/* ── Footer ── */}
       <Box
         component="footer"
-        sx={{ py: 2.5, bgcolor: '#111111', color: 'white' }}
+        sx={{ py: 2.5, bgcolor: '#111111', color: 'white', position: 'relative', zIndex: 1 }}
       >
         <Container maxWidth="lg">
           <Box sx={{ textAlign: 'center' }}>

--- a/src/shared/SeasonConfig.js
+++ b/src/shared/SeasonConfig.js
@@ -3,7 +3,8 @@
 // When bracket submissions lock (play-in tournament start). Controls:
 //   - MVP and championship pick editing deadline
 //   - Bracket submission locking deadline
-export const PLAYIN_START_DATE = new Date('2026-04-14T20:00:00Z');
+// First Play-In game: East — Apr 14, 7:30 PM ET (23:30 UTC)
+export const PLAYIN_START_DATE = new Date('2026-04-14T23:30:00Z');
 
 // When bracket submissions open (after regular season ends). Update each season.
 export const PREDICTIONS_OPEN_DATE = new Date('2026-04-13T07:00:00Z');  // April 13 2026, 10:00 AM IDT


### PR DESCRIPTION
## Summary

Adds a scrollable informational section below the hero on both `LandingPage` and `InviteLandingPage`, giving unauthenticated visitors context about the app before signing in.

## Changes

**`LandingInfoSection` (new shared component)**
- **How It Works** — 3 numbered step cards (Lock Bonus Picks → Predict bracket → Compete in league)
- **Scoring** — escalating round pills (Play-In → Finals), note that bracket picks beat live picks, plus 3 bonus callout cards (Bullseye/Crystal Ball, Bonus Picks, Early Lock Multiplier)
- **Bottom CTA** — "Sign in with Google to Join" shown only when unauthenticated

**Background**
- `og-image-clean.png` moved to `position: fixed` on the root so the background remains visible as the user scrolls into the info section

**`LandingPage`**
- Drops `LandingInfoSection` between hero and footer
- Primary CTA label updated to "Sign in with Google to Join"

**`InviteLandingPage`**
- Hero restructured into its own contained section to allow scrolling below
- Same fixed background approach
- Info section's CTA hidden when user is already authenticated
- After signing in (from hero card or bottom CTA), page scrolls to top + toast notifies user their invite is above

Closes itamaraloni/NBA-Playoffs-Brackets-App-Client#114